### PR TITLE
showing the lifecenter only when the member is a lifecenter member

### DIFF
--- a/src/pages/HomePage/Components/Header.tsx
+++ b/src/pages/HomePage/Components/Header.tsx
@@ -83,11 +83,14 @@ export const Header = ({ handleShowNav }: IProps) => {
   const profileImg = decodedToken?.profile_img ?? "";
   const name = decodedToken?.name ?? "";
   const isMinistryWorker = decodedToken?.ministry_worker
+  const isLifeCenterLeader = decodedToken?.life_center_leader
 
   const memberNavItems = [
     { label: "Home", path: relativePath.member.dashboard },
     { label: "Marketplace", path: relativePath.member.market},
-    { label: "Life Center", path: relativePath.member.lifeCenter},
+    ...(isLifeCenterLeader
+    ? [{ label: "Life Center", path: relativePath.member.lifeCenter }]
+    : []),
     // { label: "Appointments", path: "/member/appointments" },
   ];
 

--- a/src/utils/interfaces.ts
+++ b/src/utils/interfaces.ts
@@ -51,6 +51,7 @@ export interface userType {
   membership_type: string;
   ministry_worker:boolean;
   department?: string[];
+  life_center_leader?:boolean
 }
 export interface userTypeWithToken extends userType {
   iat: number;


### PR DESCRIPTION
## Description
Describe the purpose of this pull request.

this is to show the lifecenter in the nav bar only when the user is a lifecenter member

## Checklist
- [ ] Tests have been added to all functions
- [ ] Documentation has been updated
- [ ] Changes follow coding standards
