### PR TITLE
Add theme image cropper and UI updates

### DIFF
--- a/src/pages/HomePage/pages/ChurchCommunication/AnnualThemeManager.tsx
+++ b/src/pages/HomePage/pages/ChurchCommunication/AnnualThemeManager.tsx
@@ -62,7 +62,7 @@ const AnnualThemeManager = () => {
                     }}
                   />
 
-            <div>
+            <div className="grid gap-5 md:grid-cols-2 xl:grid-cols-3">
         {themes.map((theme) => (
             <AnnualThemeCard
               key={theme.id}

--- a/src/pages/HomePage/pages/ChurchCommunication/Components/AnnualThemeCard.tsx
+++ b/src/pages/HomePage/pages/ChurchCommunication/Components/AnnualThemeCard.tsx
@@ -13,6 +13,8 @@ interface AnnualTheme {
   verseReference: string;
   verse: string;
   message: string;
+  imageUrl?: string | null;
+  image?: string | null;
   isActive?: boolean;
 }
 
@@ -24,10 +26,11 @@ interface AnnualThemeCardProps {
 
 const AnnualThemeCard = ({ theme, onEdit, onDelete }: AnnualThemeCardProps) => {
   const { canManageCurrentRoute } = useRouteAccess();
+  const themeImage = theme.imageUrl || theme.image;
+
   return (
-    <div className="app-card relative rounded-xl p-6">
-      {/* Action buttons */}
-      <div className="absolute top-4 right-4 flex gap-2">
+    <div className="app-card relative overflow-hidden rounded-xl">
+      <div className="absolute top-4 right-4 z-10 flex gap-2">
         {onEdit && canManageCurrentRoute && (
           <button
             onClick={onEdit}
@@ -48,45 +51,50 @@ const AnnualThemeCard = ({ theme, onEdit, onDelete }: AnnualThemeCardProps) => {
         )}
       </div>
 
-      {/* Title row */}
-      <div className="flex items-center gap-3 mb-2">
-        <div className="flex gap-2">
-            <h2 className="text-xl font-bold text-gray-900">
-          {theme.title}
-        </h2>
-        {theme.isActive && (
-          <Badge>
-            Current theme
-          </Badge>
-        )}
+      {themeImage && (
+        <img
+          src={themeImage}
+          alt={`${theme.title} theme`}
+          className="h-44 w-full object-cover"
+        />
+      )}
+
+      <div className="p-5">
+        <div className="mb-2 flex items-start justify-between gap-3 pr-20">
+          <h2 className="text-lg font-bold text-gray-900">
+            {theme.title}
+          </h2>
+          {theme.isActive && <Badge>Current theme</Badge>}
         </div>
-        
-      </div>
 
-      {/* Year */}
-      <div className="flex items-center gap-2 text-sm text-gray-600 mb-4">
-        <CalendarIcon className="w-4 h-4" />
-        <span>{theme.year}</span>
-      </div>
+        <div className="mb-4 flex flex-wrap gap-x-4 gap-y-2 text-sm text-gray-600">
+          <span className="flex items-center gap-2">
+            <CalendarIcon className="h-4 w-4" />
+            {theme.year}
+          </span>
+          {theme.verseReference && (
+            <span className="flex items-center gap-2 font-semibold text-gray-800">
+              <BookOpenIcon className="h-4 w-4" />
+              {theme.verseReference}
+            </span>
+          )}
+        </div>
 
-      {/* Scripture */}
-      <div className="flex items-center gap-2 font-semibold text-gray-900 mb-3">
-        <BookOpenIcon className="w-4 h-4" />
-        <span>{theme.verseReference}</span>
-      </div>
+        {theme.verse && (
+          <div className="mb-4 flex gap-3">
+            <div className="w-1 shrink-0 rounded-full bg-primary" />
+            <p className="line-clamp-3 italic leading-relaxed text-gray-600">
+              “{theme.verse}”
+            </p>
+          </div>
+        )}
 
-      {/* Verse */}
-      <div className="flex gap-3 mb-4">
-        <div className="w-1 bg-primary rounded-full" />
-        <p className="italic text-gray-600 leading-relaxed">
-          “{theme.verse}”
-        </p>
+        {theme.message && (
+          <p className="line-clamp-3 leading-relaxed text-gray-700">
+            {theme.message}
+          </p>
+        )}
       </div>
-
-      {/* Description */}
-      <p className="text-gray-700 leading-relaxed">
-        {theme.message}
-      </p>
     </div>
   );
 };

--- a/src/pages/HomePage/pages/ChurchCommunication/Components/AnnualThemeForm.tsx
+++ b/src/pages/HomePage/pages/ChurchCommunication/Components/AnnualThemeForm.tsx
@@ -1,13 +1,15 @@
 import { Formik, Form, Field } from "formik";
 import * as Yup from "yup";
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { Button } from "@/components";
-import ImageUpload from "@/components/ImageUpload";
 import { FormHeader} from "@/components/ui";
 import { FormikInputDiv } from "@/components/FormikInputDiv";
 import { api } from "@/utils/api/apiCalls";
 import { usePut } from "@/CustomHooks/usePut";
 import { usePost } from "@/CustomHooks/usePost";
+import { usePictureUpload } from "@/CustomHooks/usePictureUpload";
+import { showNotification } from "@/pages/HomePage/utils";
+import ThemeImageCropper, { type CroppedThemeImage } from "./ThemeImageCropper";
 
 export interface IAnnualThemeForm {
   id?: string | number;
@@ -16,6 +18,7 @@ export interface IAnnualThemeForm {
   verseReference: string;
   verse: string;
   message: string;
+  imageUrl?: string;
   image?: string;
   isActive: boolean;
 }
@@ -26,7 +29,7 @@ const initialValues: IAnnualThemeForm = {
   verseReference: "",
   verse: "",
   message: "",
-  image: "",
+  imageUrl: "",
   isActive: false,
 };
 
@@ -48,43 +51,65 @@ const AnnualThemeFormComponent = ({
   loading,
   refetch
 }: AnnualThemeFormProps) => {
-  const [file, setFile] = useState<File | null>(null);
+  const [croppedThemeImage, setCroppedThemeImage] =
+    useState<CroppedThemeImage | null>(null);
   
   const {
         postData,
         loading: postLoading,
-        data: postSuccess,
       } = usePost(api.post.createAnnualTheme);
       const {
         updateData,
         loading: putLoading,
-        data: putSuccess,
       } = usePut(api.put.updateAnnualTheme);
+      const { handleUpload, loading: uploadLoading } = usePictureUpload();
+
+  const handleCroppedImageChange = useCallback(
+    (image: CroppedThemeImage | null) => {
+      setCroppedThemeImage(image);
+    },
+    []
+  );
 
   const handleSubmitForm = async (values: IAnnualThemeForm) => {
     try {
+      let imageUrl = values.imageUrl || values.image || "";
+
+      if (croppedThemeImage) {
+        const formData = new FormData();
+        formData.append("file", croppedThemeImage.file);
+        const uploadedImageUrl = await handleUpload(formData);
+
+        if (!uploadedImageUrl) {
+          showNotification(
+            "Theme image could not be uploaded. Please try again.",
+            "error",
+            "Theme image"
+          );
+          return;
+        }
+
+        imageUrl = uploadedImageUrl;
+      }
+
       if (providedValues && values.id) {
         const { id, ...rest } = values;
 
         const payload = {
           ...rest,
+          imageUrl: imageUrl || undefined,
         };
-
-        console.log("Updating annual theme", payload);
+        delete payload.image;
 
         await updateData(payload, { id: String(id) });
-
-        console.log("Update response", putSuccess);
       } else {
         const payload = {
           ...values,
+          imageUrl: imageUrl || undefined,
         };
-
-        console.log("Creating annual theme", payload);
+        delete payload.image;
 
         await postData(payload);
-
-        console.log("Create response", postSuccess);
       }
 
       if (refetch) {
@@ -96,6 +121,11 @@ const AnnualThemeFormComponent = ({
       }
     } catch (error) {
       console.error("Annual theme submit failed", error);
+      showNotification(
+        "Annual theme could not be saved. Please try again.",
+        "error",
+        "Theme"
+      );
     }
   };
   
@@ -173,9 +203,9 @@ const AnnualThemeFormComponent = ({
               <label className="block text-sm font-medium mb-2">
                 Theme Image (Optional)
               </label>
-              <ImageUpload
-                onFileChange={(file: File) => setFile(file)}
-                src={""}
+              <ThemeImageCropper
+                initialImageUrl={providedValues?.imageUrl || providedValues?.image}
+                onCroppedImageChange={handleCroppedImageChange}
               />
             </div>
 
@@ -202,7 +232,7 @@ const AnnualThemeFormComponent = ({
             )}
 
             <Button
-              loading={loading || postLoading || putLoading}
+              loading={loading || postLoading || putLoading || uploadLoading}
               value={providedValues ? "Save Changes" : "Create Theme"}
               onClick={handleSubmit}
             />

--- a/src/pages/HomePage/pages/ChurchCommunication/Components/ThemeImageCropper.tsx
+++ b/src/pages/HomePage/pages/ChurchCommunication/Components/ThemeImageCropper.tsx
@@ -1,0 +1,316 @@
+import { useEffect, useMemo, useState } from "react";
+
+import { showNotification } from "@/pages/HomePage/utils";
+import { validateUploadFile } from "@/utils/uploadValidation";
+
+const OUTPUT_WIDTH = 1920;
+const OUTPUT_HEIGHT = 640;
+const IMAGE_MIME_TYPES = ["image/jpeg", "image/png", "image/webp", "image/gif"];
+
+export interface CroppedThemeImage {
+  file: File;
+  previewUrl: string;
+}
+
+interface ThemeImageCropperProps {
+  initialImageUrl?: string;
+  onCroppedImageChange: (image: CroppedThemeImage | null) => void;
+}
+
+const createImage = (src: string) =>
+  new Promise<HTMLImageElement>((resolve, reject) => {
+    const image = new Image();
+    image.crossOrigin = "anonymous";
+    image.onload = () => resolve(image);
+    image.onerror = () => reject(new Error("Unable to load selected image"));
+    image.src = src;
+  });
+
+const canvasToBlob = (canvas: HTMLCanvasElement) =>
+  new Promise<Blob>((resolve, reject) => {
+    canvas.toBlob(
+      (blob) => {
+        if (!blob) {
+          reject(new Error("Unable to crop selected image"));
+          return;
+        }
+        resolve(blob);
+      },
+      "image/jpeg",
+      0.92
+    );
+  });
+
+const cropImage = async (
+  sourceUrl: string,
+  sourceFileName: string,
+  horizontalPosition: number,
+  verticalPosition: number,
+  zoom: number
+): Promise<CroppedThemeImage> => {
+  const image = await createImage(sourceUrl);
+  const canvas = document.createElement("canvas");
+  canvas.width = OUTPUT_WIDTH;
+  canvas.height = OUTPUT_HEIGHT;
+
+  const context = canvas.getContext("2d");
+  if (!context) {
+    throw new Error("Unable to prepare image crop");
+  }
+
+  const baseScale = Math.max(
+    OUTPUT_WIDTH / image.naturalWidth,
+    OUTPUT_HEIGHT / image.naturalHeight
+  );
+  const scale = baseScale * zoom;
+  const sourceWidth = OUTPUT_WIDTH / scale;
+  const sourceHeight = OUTPUT_HEIGHT / scale;
+  const sourceX =
+    (image.naturalWidth - sourceWidth) * (horizontalPosition / 100);
+  const sourceY =
+    (image.naturalHeight - sourceHeight) * (verticalPosition / 100);
+
+  context.drawImage(
+    image,
+    sourceX,
+    sourceY,
+    sourceWidth,
+    sourceHeight,
+    0,
+    0,
+    OUTPUT_WIDTH,
+    OUTPUT_HEIGHT
+  );
+
+  const blob = await canvasToBlob(canvas);
+  const fileName = sourceFileName.replace(/\.[^.]+$/, "") || "theme-image";
+  const file = new File([blob], `${fileName}-cropped.jpg`, {
+    type: "image/jpeg",
+  });
+  const previewUrl = URL.createObjectURL(blob);
+
+  return { file, previewUrl };
+};
+
+const ThemeImageCropper = ({
+  initialImageUrl,
+  onCroppedImageChange,
+}: ThemeImageCropperProps) => {
+  const [sourceUrl, setSourceUrl] = useState("");
+  const [sourceFileName, setSourceFileName] = useState("theme-image");
+  const [previewUrl, setPreviewUrl] = useState(initialImageUrl || "");
+  const [horizontalPosition, setHorizontalPosition] = useState(50);
+  const [verticalPosition, setVerticalPosition] = useState(50);
+  const [zoom, setZoom] = useState(1);
+  const [hasSelectedImage, setHasSelectedImage] = useState(false);
+
+  const inputId = useMemo(
+    () => `theme-image-upload-${Math.random().toString(36).slice(2)}`,
+    []
+  );
+
+  useEffect(() => {
+    if (!hasSelectedImage) {
+      setPreviewUrl(initialImageUrl || "");
+    }
+  }, [hasSelectedImage, initialImageUrl]);
+
+  useEffect(() => {
+    if (!sourceUrl || !hasSelectedImage) return;
+
+    let isCurrent = true;
+
+    cropImage(
+      sourceUrl,
+      sourceFileName,
+      horizontalPosition,
+      verticalPosition,
+      zoom
+    )
+      .then((croppedImage) => {
+        if (!isCurrent) {
+          URL.revokeObjectURL(croppedImage.previewUrl);
+          return;
+        }
+        setPreviewUrl((currentPreviewUrl) => {
+          if (currentPreviewUrl && currentPreviewUrl.startsWith("blob:")) {
+            URL.revokeObjectURL(currentPreviewUrl);
+          }
+          return croppedImage.previewUrl;
+        });
+        onCroppedImageChange(croppedImage);
+      })
+      .catch((error) => {
+        const message =
+          error instanceof Error ? error.message : "Unable to crop image";
+        showNotification(message, "error", "Theme image");
+      });
+
+    return () => {
+      isCurrent = false;
+    };
+  }, [
+    hasSelectedImage,
+    horizontalPosition,
+    onCroppedImageChange,
+    sourceFileName,
+    sourceUrl,
+    verticalPosition,
+    zoom,
+  ]);
+
+  useEffect(() => {
+    return () => {
+      if (sourceUrl.startsWith("blob:")) {
+        URL.revokeObjectURL(sourceUrl);
+      }
+    };
+  }, [sourceUrl]);
+
+  useEffect(() => {
+    return () => {
+      if (previewUrl.startsWith("blob:")) {
+        URL.revokeObjectURL(previewUrl);
+      }
+    };
+  }, [previewUrl]);
+
+  const handleImageChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const selectedFile = event.target.files?.[0];
+    if (!selectedFile) return;
+
+    const validation = validateUploadFile(selectedFile, {
+      allowedMimeTypes: IMAGE_MIME_TYPES,
+    });
+
+    if (!validation.valid) {
+      showNotification(
+        validation.message || "Invalid theme image selected.",
+        "error",
+        "Theme image"
+      );
+      event.target.value = "";
+      return;
+    }
+
+    setHorizontalPosition(50);
+    setVerticalPosition(50);
+    setZoom(1);
+    setSourceFileName(selectedFile.name);
+    setSourceUrl((currentSourceUrl) => {
+      if (currentSourceUrl.startsWith("blob:")) {
+        URL.revokeObjectURL(currentSourceUrl);
+      }
+      return URL.createObjectURL(selectedFile);
+    });
+    setHasSelectedImage(true);
+  };
+
+  const handleClearReplacement = () => {
+    setHasSelectedImage(false);
+    setSourceUrl((currentSourceUrl) => {
+      if (currentSourceUrl.startsWith("blob:")) {
+        URL.revokeObjectURL(currentSourceUrl);
+      }
+      return "";
+    });
+    setSourceFileName("theme-image");
+    setHorizontalPosition(50);
+    setVerticalPosition(50);
+    setZoom(1);
+    onCroppedImageChange(null);
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="overflow-hidden rounded-xl border border-gray-200 bg-gray-100">
+        {previewUrl ? (
+          <img
+            src={previewUrl}
+            alt="Theme preview"
+            className="aspect-[3/1] max-h-56 w-full object-cover"
+          />
+        ) : (
+          <label
+            htmlFor={inputId}
+            className="flex aspect-[3/1] max-h-56 w-full cursor-pointer items-center justify-center px-4 text-center text-sm text-gray-600"
+          >
+            Select a welcome header banner
+          </label>
+        )}
+      </div>
+
+      <div className="flex flex-wrap items-center gap-3">
+        <input
+          id={inputId}
+          type="file"
+          accept="image/*"
+          className="hidden"
+          onChange={handleImageChange}
+        />
+        <label
+          htmlFor={inputId}
+          className="cursor-pointer rounded-md border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+        >
+          {previewUrl ? "Replace image" : "Upload image"}
+        </label>
+        {hasSelectedImage && initialImageUrl && (
+          <button
+            type="button"
+            onClick={handleClearReplacement}
+            className="rounded-md border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+          >
+            Keep current image
+          </button>
+        )}
+      </div>
+
+      {hasSelectedImage && (
+        <div className="grid gap-3 rounded-xl border border-gray-200 p-3 md:grid-cols-3">
+          <label className="text-sm font-medium text-gray-700">
+            Zoom
+            <input
+              type="range"
+              min="1"
+              max="3"
+              step="0.05"
+              value={zoom}
+              onChange={(event) => setZoom(Number(event.target.value))}
+              className="mt-2 w-full"
+            />
+          </label>
+          <label className="text-sm font-medium text-gray-700">
+            Horizontal position
+            <input
+              type="range"
+              min="0"
+              max="100"
+              step="1"
+              value={horizontalPosition}
+              onChange={(event) =>
+                setHorizontalPosition(Number(event.target.value))
+              }
+              className="mt-2 w-full"
+            />
+          </label>
+          <label className="text-sm font-medium text-gray-700">
+            Vertical position
+            <input
+              type="range"
+              min="0"
+              max="100"
+              step="1"
+              value={verticalPosition}
+              onChange={(event) =>
+                setVerticalPosition(Number(event.target.value))
+              }
+              className="mt-2 w-full"
+            />
+          </label>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ThemeImageCropper;

--- a/src/pages/HomePage/pages/DashBoard/Components/WelcomeHeader.tsx
+++ b/src/pages/HomePage/pages/DashBoard/Components/WelcomeHeader.tsx
@@ -2,6 +2,9 @@ import { useUserStore } from "@/store/userStore";
 
 export const WelcomeHeader = ({ showFull = false, theme }: { showFull?: boolean, theme?: any }) => {
   const name = useUserStore((state) => state.name);
+  const themeImage = theme?.imageUrl || theme?.image;
+  const defaultBanner =
+    "https://res.cloudinary.com/akwaah/image/upload/v1740860331/background_oswjfy.jpg";
 
   return (
     <div
@@ -12,9 +15,10 @@ export const WelcomeHeader = ({ showFull = false, theme }: { showFull?: boolean,
       }`}
     >
       <div
-        className={` bg-[url('https://res.cloudinary.com/akwaah/image/upload/v1740860331/background_oswjfy.jpg')] bg-no-repeat bg-right bg-cover py-6   text-white relative overflow-hidden ${
+        className={`bg-no-repeat bg-center bg-cover py-6 text-white relative overflow-hidden ${
           showFull ? "app-layout-container py-4" : "rounded-xl px-6"
         }`}
+        style={{ backgroundImage: `url(${themeImage || defaultBanner})` }}
       >
         <div className="absolute inset-0 bg-black opacity-70 backdrop-blur-sm rounded-xl"></div>
 


### PR DESCRIPTION
Introduce ThemeImageCropper to allow selecting, cropping and previewing banner images (zoom/position) and produce a CroppedThemeImage file. Integrate cropping into AnnualThemeForm (replace ImageUpload) and upload via usePictureUpload, including upload loading state and error notifications; send imageUrl in create/update payloads. Update AnnualThemeCard to display theme image (imageUrl or image), adjust card layout and typography. Add grid layout in AnnualThemeManager and make WelcomeHeader use theme image with a default banner fallback. Also include input validation and blob URL cleanup for previews.

## Description
Describe the purpose of this pull request.

## Checklist
- [ ] Tests have been added to all functions
- [ ] Documentation has been updated
- [ ] Changes follow coding standards
