### PR TITLE
Add finance export feature and download UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@types/react-datepicker": "^6.2.0",
         "axios": "^1.15.2",
         "chart.js": "^4.4.2",
+        "docx": "^9.6.1",
         "dompurify": "^3.3.1",
         "exceljs": "^4.4.0",
         "formik": "^2.4.6",
@@ -6843,6 +6844,50 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/docx": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/docx/-/docx-9.6.1.tgz",
+      "integrity": "sha512-ZJja9/KBUuFC109sCMzovoq2GR2wCG/AuxivjA+OHj/q0TEgJIm3S7yrlUxIy3B+bV8YDj/BiHfWyrRFmyWpDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^25.2.3",
+        "hash.js": "^1.1.7",
+        "jszip": "^3.10.1",
+        "nanoid": "^5.1.3",
+        "xml": "^1.0.1",
+        "xml-js": "^1.6.8"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/docx/node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/docx/node_modules/nanoid": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.11.tgz",
+      "integrity": "sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
+    },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
@@ -8317,6 +8362,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hash.js": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
       }
     },
     "node_modules/hasown": {
@@ -10796,6 +10851,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
+    },
     "node_modules/minimatch": {
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
@@ -12469,6 +12530,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
     "node_modules/saxes": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
@@ -13631,6 +13701,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.1",
@@ -15010,6 +15086,24 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==",
+      "license": "MIT"
+    },
+    "node_modules/xml-js": {
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz",
+      "integrity": "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": "^1.2.4"
+      },
+      "bin": {
+        "xml-js": "bin/cli.js"
+      }
     },
     "node_modules/xmlchars": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@types/react-datepicker": "^6.2.0",
     "axios": "^1.15.2",
     "chart.js": "^4.4.2",
+    "docx": "^9.6.1",
     "dompurify": "^3.3.1",
     "exceljs": "^4.4.0",
     "formik": "^2.4.6",

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -57,7 +57,7 @@ export const Button = ({
   const variantClass = {
     primary: "bg-primary text-white hover:bg-primary/90 hover:text-white",
     secondary:
-      "border border-primary/30 bg-white text-primary hover:border-primary/60 hover:bg-primary/5 ",
+      "border border-primary/30 bg-white text-primary hover:border-white hover:bg-primary/50 hover:text-white ",
     ghost: "bg-transparent text-primary hover:bg-primary/5 ",
     default: "bg-primary text-white hover:bg-primary/90 hover:text-white",
   }[variant];

--- a/src/pages/HomePage/pages/FinanceManagement/pages/FinanceDetailPage.tsx
+++ b/src/pages/HomePage/pages/FinanceManagement/pages/FinanceDetailPage.tsx
@@ -12,6 +12,10 @@ import {
   FinanceSaveAction,
   FinancialRecord,
 } from "@/utils/api/finance/interface";
+import {
+  downloadFinanceDetails,
+  FinanceExportFormat,
+} from "../utils/exportFinanceDetails";
 
 const unwrapFinancialPayload = (
   responseData: FinancialRecord | FinancialRecord[] | FinanceData | undefined
@@ -45,6 +49,11 @@ const FinanceDetailPage = () => {
   const [formMode, setFormMode] = React.useState<"create" | "view" | "edit">(
     "view"
   );
+  const [downloadOpen, setDownloadOpen] = React.useState(false);
+  const [downloadingFormat, setDownloadingFormat] = React.useState<
+    FinanceExportFormat | ""
+  >("");
+  const downloadMenuRef = React.useRef<HTMLDivElement | null>(null);
 
   const { data, refetch, loading, error } = useFetch(
     api.fetch.fetchFinancial,
@@ -62,6 +71,22 @@ const FinanceDetailPage = () => {
         financialData.metaData.week || ""
       }`
     : "Financial record";
+
+  React.useEffect(() => {
+    if (!downloadOpen) return;
+
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        downloadMenuRef.current &&
+        !downloadMenuRef.current.contains(event.target as Node)
+      ) {
+        setDownloadOpen(false);
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [downloadOpen]);
 
   const handleUpdateFinancial = async (
     values: FinanceData,
@@ -94,6 +119,25 @@ const FinanceDetailPage = () => {
           : "Failed to update financial record";
       showNotification(message, "error");
       return false;
+    }
+  };
+
+  const handleDownload = async (format: FinanceExportFormat) => {
+    if (!financialData) return;
+
+    setDownloadingFormat(format);
+    setDownloadOpen(false);
+
+    try {
+      await downloadFinanceDetails(financialData, format);
+    } catch (error: unknown) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : "Unable to download financial details.";
+      showNotification(message, "error");
+    } finally {
+      setDownloadingFormat("");
     }
   };
 
@@ -133,11 +177,53 @@ const FinanceDetailPage = () => {
             </div>
           </div>
 
-          <div>
+          <div className="flex  justify-end gap-3">
+            {formMode === "view" && (
+              <div className="relative" ref={downloadMenuRef}>
+                <Button
+                  value={downloadingFormat ? "Downloading..." : "Download"}
+                  variant="secondary"
+                  requireManageAccess={false}
+                  disabled={Boolean(downloadingFormat)}
+                  loading={Boolean(downloadingFormat)}
+                  onClick={() => setDownloadOpen((open) => !open)}
+                />
+
+                {downloadOpen && (
+                  <div className="absolute right-0 z-20 mt-2 w-56 overflow-hidden rounded-lg border border-gray-200 bg-white py-1 text-sm shadow-lg">
+                    <button
+                      type="button"
+                      className="block w-full px-4 py-2 text-left text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60"
+                      disabled={Boolean(downloadingFormat)}
+                      onClick={() => void handleDownload("docx")}
+                    >
+                      Download as DOCX
+                    </button>
+                    <button
+                      type="button"
+                      className="block w-full px-4 py-2 text-left text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60"
+                      disabled={Boolean(downloadingFormat)}
+                      onClick={() => void handleDownload("xlsx")}
+                    >
+                      Download as Spreadsheet
+                    </button>
+                    <button
+                      type="button"
+                      className="block w-full px-4 py-2 text-left text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60"
+                      disabled={Boolean(downloadingFormat)}
+                      onClick={() => void handleDownload("pdf")}
+                    >
+                      Download as PDF
+                    </button>
+                  </div>
+                )}
+              </div>
+            )}
+
             {formMode === "view" && financialData.isEditable !== false && (
               <Button
                 value="Edit Financials"
-                variant="secondary"
+                variant="primary"
                 requireManageAccess={false}
                 onClick={() => setFormMode("edit")}
               />

--- a/src/pages/HomePage/pages/FinanceManagement/utils/exportFinanceDetails.ts
+++ b/src/pages/HomePage/pages/FinanceManagement/utils/exportFinanceDetails.ts
@@ -1,0 +1,601 @@
+import {
+  AlignmentType,
+  Document,
+  Packer,
+  Paragraph,
+  Table,
+  TableCell,
+  TableRow,
+  TextRun,
+  WidthType,
+} from "docx";
+import { Workbook } from "exceljs";
+import { jsPDF } from "jspdf";
+import { downloadBlobFile } from "@/utils/helperFunctions";
+import { FinanceData } from "@/utils/api/finance/interface";
+import { buildFinanceSummary } from "./helperFunctions";
+
+export type FinanceExportFormat = "docx" | "xlsx" | "pdf";
+
+type ExportRow = Array<string | number>;
+
+type ExportSection = {
+  title: string;
+  type: "metadata" | "financial";
+  columns?: TableColumn[];
+  rows: ExportRow[];
+};
+
+type TableColumn = {
+  header: string;
+  width: number;
+  align: "left" | "right";
+};
+
+const MIME_TYPES: Record<FinanceExportFormat, string> = {
+  docx: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  xlsx: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  pdf: "application/pdf",
+};
+
+const FINANCIAL_COLUMNS: TableColumn[] = [
+  { header: "Item / Movement", width: 40, align: "left" },
+  { header: "", width: 10, align: "left" },
+  { header: "Portion", width: 14, align: "right" },
+  { header: "Amount / Actuals", width: 18, align: "right" },
+  { header: "Funds / Adjusted", width: 18, align: "right" },
+];
+
+const METADATA_COLUMNS: TableColumn[] = [
+  { header: "Field", width: 35, align: "left" },
+  { header: "Value", width: 65, align: "left" },
+];
+
+const getColumns = (section: ExportSection): TableColumn[] =>
+  section.columns ||
+  (section.type === "metadata" ? METADATA_COLUMNS : FINANCIAL_COLUMNS);
+
+const createFinancialColumns = ({
+  itemHeader = "Item / Movement",
+  portionHeader = "",
+  amountHeader = "Amount / Actuals",
+  fundsHeader = "Funds / Adjusted",
+}: {
+  itemHeader?: string;
+  portionHeader?: string;
+  amountHeader?: string;
+  fundsHeader?: string;
+} = {}): TableColumn[] =>
+  FINANCIAL_COLUMNS.map((column, index) => ({
+    ...column,
+    header:
+      index === 0
+        ? itemHeader
+        : index === 2
+        ? portionHeader
+        : index === 3
+        ? amountHeader
+        : index === 4
+        ? fundsHeader
+        : column.header,
+  }));
+
+const toNumber = (value: unknown): number => {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+};
+
+const toRatio = (value: unknown): number => {
+  const numeric = toNumber(value);
+  return Math.abs(numeric) <= 1 ? numeric : numeric / 100;
+};
+
+const formatAmount = (value: unknown): string =>
+  toNumber(value).toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+
+const formatPercent = (value: unknown): string => {
+  const percent = toRatio(value) * 100;
+  const formatted = Number.isInteger(percent)
+    ? String(percent)
+    : percent.toFixed(2).replace(/\.?0+$/, "");
+  return `${formatted}%`;
+};
+
+const formatStatus = (value?: string | null): string =>
+  value
+    ? value
+        .toLowerCase()
+        .split("_")
+        .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+        .join(" ")
+    : "";
+
+const safeText = (value: unknown): string => {
+  if (value === null || value === undefined || value === "") return "";
+  return String(value);
+};
+
+const getFileBaseName = (financeData: FinanceData): string => {
+  const meta = financeData.metaData;
+  const parts = [
+    "finance-details",
+    meta?.month,
+    meta?.year,
+    meta?.week,
+  ].filter(Boolean);
+
+  return parts
+    .join("-")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+};
+
+const createExportSections = (financeData: FinanceData): ExportSection[] => {
+  const summary = buildFinanceSummary(financeData);
+  const balance = financeData.balance;
+
+  return [
+    {
+      title: "Metadata",
+      type: "metadata",
+      rows: [
+        ["Month", safeText(financeData.metaData?.month)],
+        ["Year", safeText(financeData.metaData?.year)],
+        ["Week", safeText(financeData.metaData?.week)],
+        ["From", safeText(financeData.metaData?.from)],
+        ["To", safeText(financeData.metaData?.to)],
+        ["Period Date", safeText(financeData.metaData?.periodDate)],
+        ["Status", formatStatus((financeData as any).status)],
+        ["Created By", safeText(financeData.metaData?.createdBy)],
+        ["Created Date", safeText(financeData.metaData?.createdDate)],
+        ["Updated By", safeText(financeData.metaData?.updatedBy)],
+        ["Updated Date", safeText(financeData.metaData?.updatedDate)],
+      ],
+    },
+    {
+      title: "Receipts",
+      type: "financial",
+      columns: createFinancialColumns({
+        itemHeader: "Item",
+        amountHeader: "Amount",
+        fundsHeader: "Funds",
+      }),
+      rows: [
+        ...(financeData.receipts || []).map((receipt) => [
+          receipt.item,
+          "",
+          "",
+          formatAmount(receipt.amount),
+          "",
+        ]),
+        [
+          "Total Receipts",
+          "",
+          "",
+          formatAmount(summary.receipts.total),
+          formatAmount(summary.receipts.total),
+        ],
+      ],
+    },
+    {
+      title: "Tithe",
+      type: "financial",
+      columns: createFinancialColumns({
+        itemHeader: "Item",
+        portionHeader: "Portion",
+        amountHeader: "Amount",
+        fundsHeader: "Funds",
+      }),
+      rows: [
+        [
+          financeData.tithe?.totalTithe?.label || "Tithe",
+          "",
+          formatPercent(financeData.tithe?.totalTithe?.percentage),
+          formatAmount(summary.tithe.amount),
+          formatAmount(summary.tithe.fundsAfterTithe),
+        ],
+        ...summary.tithe.breakdown.map((entry: any) => [
+          entry.item,
+          "",
+          formatPercent(entry.percentage),
+          formatAmount(entry.amount),
+          "",
+        ]),
+      ],
+    },
+    {
+      title: "Payments",
+      type: "financial",
+      columns: createFinancialColumns({
+        itemHeader: "Item",
+        amountHeader: "Amount",
+        fundsHeader: "Funds",
+      }),
+      rows: [
+        ...(financeData.payments || []).map((payment) => [
+          payment.item,
+          "",
+          "",
+          formatAmount(payment.amount),
+          "",
+        ]),
+        [
+          "Total Payments",
+          "",
+          "",
+          formatAmount(summary.payments.total),
+          formatAmount(summary.balance.excessAfterPayments),
+        ],
+      ],
+    },
+    {
+      title: "Balance Summary",
+      type: "financial",
+      columns: createFinancialColumns({
+        itemHeader: "Item",
+        amountHeader: "Amount",
+        fundsHeader: "Funds",
+      }),
+      rows: [
+        [
+          balance?.ExcessOfReceiptsOverPayments?.item ||
+            "Excess of Receipts over Payments",
+          "",
+          "",
+          formatAmount(summary.balance.excessAfterPayments),
+          "",
+        ],
+        [
+          balance?.ReserveForSavings?.item || "Reserved for Savings",
+          "",
+          "",
+          formatAmount(summary.balance.reserveForSavings),
+          "",
+        ],
+        [
+          balance?.BalanceAmount?.item || "Balance",
+          "",
+          "",
+          formatAmount(summary.balance.netBalance),
+          "",
+        ],
+        [
+          balance?.WeeklyRefund?.item || "Weekly Refund",
+          "",
+          "",
+          formatAmount(summary.balance.weeklyRefund),
+          "",
+        ],
+        [
+          balance?.OfficeMaintenanceReserve?.item ||
+            "Office Maintenance Reserve",
+          "",
+          "",
+          formatAmount(summary.balance.officeReserve),
+          "",
+        ],
+        [
+          "Total Balance",
+          "",
+          "",
+          formatAmount(summary.balance.finalBalance),
+          formatAmount(summary.balance.finalBalance),
+        ],
+      ],
+    },
+    {
+      title: "Fund Allocation",
+      type: "financial",
+      columns: createFinancialColumns({
+        itemHeader: "Movement",
+        portionHeader: "Portions",
+        amountHeader: "Actuals",
+        fundsHeader: "Adjusted",
+      }),
+      rows: [
+        ...summary.fundAllocations.map((allocation: any) => [
+          allocation.movement,
+          "",
+          formatPercent(allocation.portionPercent),
+          formatAmount(allocation.actual),
+          formatAmount(allocation.adjusted),
+        ]),
+        [
+          "Total Fund Allocation",
+          "",
+          formatPercent(
+            summary.fundAllocations.reduce(
+              (total: number, allocation: any) =>
+                total + toRatio(allocation.portionPercent),
+              0
+            )
+          ),
+          formatAmount(summary.fundAllocationTotals.actual),
+          formatAmount(summary.fundAllocationTotals.adjusted),
+        ],
+      ],
+    },
+  ];
+};
+
+const createTitle = (financeData: FinanceData): string => {
+  const meta = financeData.metaData;
+  return [
+    "Receipts and Payments Account",
+    [meta?.month, meta?.year, meta?.week].filter(Boolean).join(" "),
+  ]
+    .filter(Boolean)
+    .join(" - ");
+};
+
+const createDocxCell = (
+  value: string | number,
+  column: TableColumn,
+  bold = false
+) =>
+  new TableCell({
+    width: { size: column.width, type: WidthType.PERCENTAGE },
+    children: [
+      new Paragraph({
+        alignment:
+          column.align === "right" ? AlignmentType.RIGHT : AlignmentType.LEFT,
+        children: [new TextRun({ text: safeText(value), bold })],
+      }),
+    ],
+  });
+
+const createDocxTable = (section: ExportSection) => {
+  const columns = getColumns(section);
+
+  return new Table({
+    width: { size: 100, type: WidthType.PERCENTAGE },
+    rows: [
+      new TableRow({
+        children: columns.map((column) =>
+          createDocxCell(column.header, column, true)
+        ),
+      }),
+      ...section.rows.map(
+        (row) =>
+          new TableRow({
+            children: columns.map((column, index) =>
+              createDocxCell(row[index] ?? "", column)
+            ),
+          })
+      ),
+    ],
+  });
+};
+
+const buildDocxBlob = async (
+  financeData: FinanceData,
+  sections: ExportSection[]
+): Promise<Blob> => {
+  const children = [
+    new Paragraph({
+      alignment: AlignmentType.CENTER,
+      spacing: { after: 300 },
+      children: [
+        new TextRun({
+          text: createTitle(financeData),
+          bold: true,
+          size: 32,
+        }),
+      ],
+    }),
+    ...sections.flatMap((section) => [
+      new Paragraph({
+        spacing: { before: 240, after: 120 },
+        children: [new TextRun({ text: section.title, bold: true, size: 24 })],
+      }),
+      createDocxTable(section),
+    ]),
+  ];
+
+  const doc = new Document({
+    sections: [{ children }],
+  });
+
+  return Packer.toBlob(doc);
+};
+
+const buildXlsxBlob = async (
+  financeData: FinanceData,
+  sections: ExportSection[]
+): Promise<Blob> => {
+  const workbook = new Workbook();
+  const worksheet = workbook.addWorksheet("Finance Details");
+
+  worksheet.addRow([createTitle(financeData)]);
+  worksheet.getRow(1).font = { bold: true, size: 16 };
+  worksheet.addRow([]);
+
+  sections.forEach((section) => {
+    const columns = getColumns(section);
+    const titleRow = worksheet.addRow([section.title]);
+    titleRow.font = { bold: true, size: 13 };
+
+    const headerRow = worksheet.addRow(columns.map((column) => column.header));
+    headerRow.font = { bold: true };
+    headerRow.fill = {
+      type: "pattern",
+      pattern: "solid",
+      fgColor: { argb: "FFEFEFEF" },
+    };
+
+    section.rows.forEach((row) => worksheet.addRow(row));
+    worksheet.addRow([]);
+  });
+
+  worksheet.columns = [
+    { width: 34 },
+    { width: 10 },
+    { width: 14 },
+    { width: 18 },
+    { width: 18 },
+  ];
+
+  worksheet.eachRow((row) => {
+    row.eachCell((cell, colNumber) => {
+      if (colNumber >= 3) {
+        cell.alignment = { horizontal: "right" };
+      }
+    });
+  });
+
+  const buffer = await workbook.xlsx.writeBuffer();
+  return new Blob([buffer as BlobPart], { type: MIME_TYPES.xlsx });
+};
+
+const addPdfText = (
+  doc: jsPDF,
+  text: string,
+  x: number,
+  y: number,
+  width: number,
+  align: "left" | "right"
+) => {
+  const lines = doc.splitTextToSize(text, width);
+  lines.forEach((line: string, index: number) => {
+    doc.text(line, align === "right" ? x + width : x, y + index * 5, {
+      align,
+    });
+  });
+};
+
+const getPdfColumnWidths = (section: ExportSection): number[] =>
+  section.type === "metadata" ? [58, 124] : [73, 18, 24, 33, 34];
+
+const getPdfRowHeight = (
+  doc: jsPDF,
+  row: ExportRow,
+  columnWidths: number[]
+): number => {
+  const maxLines = row.reduce((count, cell, index) => {
+    const lines = doc.splitTextToSize(safeText(cell), columnWidths[index] - 4);
+    return Math.max(count, lines.length);
+  }, 1);
+
+  return Math.max(8, maxLines * 5 + 4);
+};
+
+const drawPdfTableRow = (
+  doc: jsPDF,
+  row: ExportRow,
+  columns: TableColumn[],
+  columnWidths: number[],
+  y: number,
+  height: number,
+  isHeader = false
+) => {
+  const margin = 14;
+  let x = margin;
+
+  doc.setFont("helvetica", isHeader ? "bold" : "normal");
+  doc.setFillColor(isHeader ? 239 : 255, isHeader ? 239 : 255, isHeader ? 239 : 255);
+
+  row.forEach((cell, index) => {
+    const width = columnWidths[index];
+    doc.rect(x, y, width, height, isHeader ? "FD" : "S");
+    addPdfText(
+      doc,
+      safeText(cell),
+      x + 2,
+      y + 5,
+      width - 4,
+      columns[index]?.align ?? "left"
+    );
+    x += width;
+  });
+};
+
+const drawPdfSectionHeader = (
+  doc: jsPDF,
+  section: ExportSection,
+  y: number
+): number => {
+  const columns = getColumns(section);
+  const columnWidths = getPdfColumnWidths(section);
+
+  doc.setFont("helvetica", "bold");
+  doc.text(section.title, 14, y);
+  const headerY = y + 4;
+  drawPdfTableRow(
+    doc,
+    columns.map((column) => column.header),
+    columns,
+    columnWidths,
+    headerY,
+    8,
+    true
+  );
+
+  return headerY + 8;
+};
+
+const buildPdfBlob = (
+  financeData: FinanceData,
+  sections: ExportSection[]
+): Blob => {
+  const doc = new jsPDF({ unit: "mm", format: "a4" });
+  const cursor = { y: 16 };
+  const pageHeight = doc.internal.pageSize.getHeight();
+  const bottomMargin = 14;
+
+  doc.setFontSize(16);
+  doc.setFont("helvetica", "bold");
+  doc.text(createTitle(financeData), 14, cursor.y);
+  cursor.y += 10;
+  doc.setFontSize(10);
+
+  sections.forEach((section) => {
+    const columns = getColumns(section);
+    const columnWidths = getPdfColumnWidths(section);
+
+    if (cursor.y > pageHeight - 32) {
+      doc.addPage();
+      cursor.y = 16;
+    }
+
+    cursor.y = drawPdfSectionHeader(doc, section, cursor.y);
+
+    section.rows.forEach((row) => {
+      const rowHeight = getPdfRowHeight(doc, row, columnWidths);
+
+      if (cursor.y + rowHeight > pageHeight - bottomMargin) {
+        doc.addPage();
+        cursor.y = drawPdfSectionHeader(doc, section, 16);
+      }
+
+      drawPdfTableRow(doc, row, columns, columnWidths, cursor.y, rowHeight);
+      cursor.y += rowHeight;
+    });
+
+    cursor.y += 6;
+  });
+
+  return doc.output("blob");
+};
+
+export const downloadFinanceDetails = async (
+  financeData: FinanceData,
+  format: FinanceExportFormat
+) => {
+  const sections = createExportSections(financeData);
+  const fileName = `${getFileBaseName(financeData) || "finance-details"}.${format}`;
+  const blob =
+    format === "docx"
+      ? await buildDocxBlob(financeData, sections)
+      : format === "xlsx"
+      ? await buildXlsxBlob(financeData, sections)
+      : buildPdfBlob(financeData, sections);
+
+  downloadBlobFile(
+    blob.type ? blob : new Blob([blob], { type: MIME_TYPES[format] }),
+    fileName
+  );
+};


### PR DESCRIPTION
Add a full export capability for finance records and integrate a download UI in the finance detail page.

- Add src/pages/HomePage/pages/FinanceManagement/utils/exportFinanceDetails.ts: implements export logic for DOCX, XLSX and PDF (builders for docx using docx, Excel via exceljs, and PDF via jsPDF), formatting helpers, and a downloadFinanceDetails(fn) entry point.
- Integrate downloads into FinanceDetailPage.tsx: import downloadFinanceDetails, add download menu UI, click-outside handling, download state, and handler to trigger exports with error notifications.
- Update Button.tsx: adjust secondary variant hover styles and change the "Edit Financials" button to primary for better emphasis.
- Add docx to package.json dependencies (lockfile updated accordingly).

This enables users to download finance details in multiple formats and includes UX improvements around the download flow and button styling.

## Description
Describe the purpose of this pull request.

## Checklist
- [ ] Tests have been added to all functions
- [ ] Documentation has been updated
- [ ] Changes follow coding standards
