### PR TITLE
Clearable Selects, empty amounts, conflict modal

### DIFF
--- a/src/pages/HomePage/Components/reusable/SelectField.tsx
+++ b/src/pages/HomePage/Components/reusable/SelectField.tsx
@@ -44,7 +44,7 @@ export const SelectField: React.FC<SelectFieldProps> = ({
   error,
   searchable,
   searchPlaceholder = "Search...",
-  clearable = false,
+  clearable = true,
   sortOptions = true,
   className,
   inputClassName,
@@ -91,6 +91,8 @@ export const SelectField: React.FC<SelectFieldProps> = ({
   const selectedOption = sortedOptions.find((option) =>
     areOptionValuesEqual(option.value, value)
   );
+  const hasValue = value !== null && value !== undefined && String(value) !== "";
+  const clearLabel = `Clear ${label ?? placeholder ?? id}`;
 
   /* ---------------------------- styles ---------------------------- */
 
@@ -131,6 +133,11 @@ export const SelectField: React.FC<SelectFieldProps> = ({
     clearSelection();
   };
 
+  const handleNativeChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const nextValue = event.target.value;
+    onChange(id, clearable && nextValue === "" ? null : nextValue);
+  };
+
   const handleClickOutside = useCallback((e: MouseEvent) => {
     if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
       setIsOpen(false);
@@ -160,29 +167,60 @@ export const SelectField: React.FC<SelectFieldProps> = ({
           </label>
         )}
 
-        <select
-          id={id}
-          name={id}
-          value={value ?? ""}
-          disabled={disabled}
-          onChange={(e) => onChange(id, e.target.value)}
-          className={clsx(
-            baseControl,
-            stateStyles,
-            inputClassName
-          )}
-        >
-          <option value="" className="text-gray-400">
-            {placeholder}
-          </option>
-
-          {sortedOptions.map(option => (
-            <option key={option.value} value={option.value}>
-              {getOptionLabel(option)}
+        <div className="relative">
+          <select
+            id={id}
+            name={id}
+            value={value ?? ""}
+            disabled={disabled}
+            onChange={handleNativeChange}
+            className={clsx(
+              baseControl,
+              stateStyles,
+              inputClassName
+            )}
+            style={
+              clearable && hasValue ? { paddingRight: "3.25rem" } : undefined
+            }
+          >
+            <option value="" className="text-gray-400">
+              {placeholder}
             </option>
-          ))}
-        </select>
-          {(!error&&helperText) && <span className="text-xs text-gray-600">{helperText}</span>}
+
+            {sortedOptions.map(option => (
+              <option key={option.value} value={option.value}>
+                {getOptionLabel(option)}
+              </option>
+            ))}
+          </select>
+
+          {clearable && hasValue && !disabled ? (
+            <button
+              type="button"
+              aria-label={clearLabel}
+              title={clearLabel}
+              onMouseDown={handleClear}
+              onClick={handleClear}
+              className="absolute right-8 top-1/2 inline-flex h-6 w-6 -translate-y-1/2 items-center justify-center rounded-full text-gray-400 transition hover:bg-gray-100 hover:text-gray-600 focus:outline-none focus:ring-2 focus:ring-primary/20"
+            >
+              <svg
+                aria-hidden="true"
+                className="h-3.5 w-3.5"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M6 6l12 12M18 6L6 18"
+                />
+              </svg>
+            </button>
+          ) : null}
+        </div>
+        {(!error&&helperText) && <span className="text-xs text-gray-600">{helperText}</span>}
         {error && <span className="text-xs text-error">{error}</span>}
       </div>
     );
@@ -219,35 +257,15 @@ export const SelectField: React.FC<SelectFieldProps> = ({
             stateStyles,
             inputClassName
           )}
-          >
+          style={
+            clearable && hasValue ? { paddingRight: "4rem" } : undefined
+          }
+        >
           <span className={selectedOption ? "text-gray-900" : "text-gray-500"}>
             {selectedOption ? getOptionLabel(selectedOption) : placeholder}
           </span>
 
           <span className="ml-3 flex items-center gap-2">
-            {clearable && selectedOption ? (
-              <span
-                aria-hidden="true"
-                onMouseDown={handleClear}
-                onClick={handleClear}
-                className="inline-flex h-6 w-6 items-center justify-center rounded-full text-gray-400 transition hover:bg-gray-100 hover:text-gray-600"
-              >
-                <svg
-                  className="h-3.5 w-3.5"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M6 6l12 12M18 6L6 18"
-                  />
-                </svg>
-              </span>
-            ) : null}
-
             <svg
               className={clsx(
                 "h-4 w-4 transition-transform",
@@ -266,6 +284,32 @@ export const SelectField: React.FC<SelectFieldProps> = ({
             </svg>
           </span>
         </button>
+
+        {clearable && hasValue && !disabled ? (
+          <button
+            type="button"
+            aria-label={clearLabel}
+            title={clearLabel}
+            onMouseDown={handleClear}
+            onClick={handleClear}
+            className="absolute right-8 top-5 inline-flex h-6 w-6 -translate-y-1/2 items-center justify-center rounded-full text-gray-400 transition hover:bg-gray-100 hover:text-gray-600 focus:outline-none focus:ring-2 focus:ring-primary/20"
+          >
+            <svg
+              aria-hidden="true"
+              className="h-3.5 w-3.5"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M6 6l12 12M18 6L6 18"
+              />
+            </svg>
+          </button>
+        ) : null}
 
         {/* Dropdown */}
         {isOpen && (

--- a/src/pages/HomePage/pages/Requisitions/components/EditableTable.tsx
+++ b/src/pages/HomePage/pages/Requisitions/components/EditableTable.tsx
@@ -71,8 +71,8 @@ const TableInput = ({
 
 interface TableRow {
   name: string;
-  quantity: number;
-  amount: number;
+  quantity: number | "";
+  amount: number | "";
   total: number;
   id: string | number;
   image_url?: string;
@@ -133,7 +133,7 @@ const EditableTable: React.FC<EditableTableProps> = ({
     }
   };
 
-  const formatAmount = (value: number) => {
+  const formatAmount = (value: number | "") => {
     const parsed = Number(value);
     return amountFormatter.format(Number.isFinite(parsed) ? parsed : 0);
   };

--- a/src/pages/HomePage/pages/Requisitions/hooks/useAddRequisition.ts
+++ b/src/pages/HomePage/pages/Requisitions/hooks/useAddRequisition.ts
@@ -19,6 +19,8 @@ type SubmitOptions = {
 
 type RequisitionMutationResponse = ApiResponse<Record<string, unknown>>;
 const REQUESTS_BASE_PATH = "/home/requests";
+const APPROVER_REQUESTER_CONFLICT_MARKER =
+  "you are assigned as an approver for this requisition";
 
 const isPositiveInteger = (value: unknown): value is number => {
   const normalized = Number(value);
@@ -136,6 +138,8 @@ export const useAddRequisition = () => {
   const [error, setError] = useState<Error | null>(null);
   const [data, setData] = useState<RequisitionMutationResponse | null>(null);
   const [signature, setSignature] = useState<string>("");
+  const [approverConflictMessage, setApproverConflictMessage] =
+    useState<string>("");
 
   const navigate = useNavigate();
   const currencies = useMemo(
@@ -186,6 +190,10 @@ export const useAddRequisition = () => {
   const closeModal = () => {
     setOpenSignature(false);
   };
+
+  const closeApproverConflictModal = useCallback(() => {
+    setApproverConflictMessage("");
+  }, []);
 
   const imageChange = useCallback((nextImages: image[]) => {
     setImages((previousImages) =>
@@ -265,8 +273,8 @@ export const useAddRequisition = () => {
     async (val: RequisitionFormValues, options?: SubmitOptions) => {
       const products = rows.map((item) => ({
         name: item.name,
-        quantity: item.quantity,
-        unitPrice: item.amount,
+        quantity: Number(item.quantity || 0),
+        unitPrice: Number(item.amount || 0),
         image_url: item.image_url || undefined,
         image: item.image_url || undefined,
         id: item?.id,
@@ -356,6 +364,15 @@ export const useAddRequisition = () => {
           error instanceof Error ? error : new Error("Unknown error");
         setError(normalizedError);
 
+        if (
+          error instanceof ApiError &&
+          normalizedError.message
+            .toLowerCase()
+            .includes(APPROVER_REQUESTER_CONFLICT_MARKER)
+        ) {
+          setApproverConflictMessage(normalizedError.message);
+        }
+
         if (!(error instanceof ApiError)) {
           handleOpenNotification(normalizedError.message, "error");
         }
@@ -374,6 +391,8 @@ export const useAddRequisition = () => {
     data,
     handleAddSignature,
     closeModal,
+    approverConflictMessage,
+    closeApproverConflictModal,
     openSignature,
     handleUploadImage,
     imageChange,

--- a/src/pages/HomePage/pages/Requisitions/hooks/useRequisitionDetail.ts
+++ b/src/pages/HomePage/pages/Requisitions/hooks/useRequisitionDetail.ts
@@ -59,6 +59,9 @@ const notificationMessages: Record<
   },
 };
 
+const APPROVER_REQUESTER_CONFLICT_MARKER =
+  "you are assigned as an approver for this requisition";
+
 const getResponseMessage = (payload: unknown, fallback: string): string => {
   if (!payload || typeof payload !== "object") {
     return fallback;
@@ -227,6 +230,8 @@ export const useRequisitionDetail = () => {
   const [openSubmitRequestSignature, setOpenSubmitRequestSignature] =
     useState(false);
   const [requestSignature, setRequestSignature] = useState("");
+  const [approverConflictMessage, setApproverConflictMessage] =
+    useState<string>("");
   const [openSimilarItemsModal, setOpenSimilarItemsModal] = useState(false);
   const [similarItemGroups, setSimilarItemGroups] = useState<
     SimilarItemComparisonGroup[]
@@ -663,6 +668,10 @@ export const useRequisitionDetail = () => {
     setOpenSubmitRequestSignature(false);
   }, []);
 
+  const closeApproverConflictModal = useCallback(() => {
+    setApproverConflictMessage("");
+  }, []);
+
   const handleRequestSignature = useCallback((signature: string) => {
     setRequestSignature(signature.trim());
   }, []);
@@ -710,6 +719,13 @@ export const useRequisitionDetail = () => {
       closeSubmitRequestModal();
       await refreshDetails();
     } catch (error) {
+      if (
+        error instanceof ApiError &&
+        error.message.toLowerCase().includes(APPROVER_REQUESTER_CONFLICT_MARKER)
+      ) {
+        setApproverConflictMessage(error.message);
+      }
+
       if (!(error instanceof ApiError)) {
         handleOpenNotification(
           error instanceof Error
@@ -780,6 +796,8 @@ export const useRequisitionDetail = () => {
     openSubmitRequestSignature,
     openSubmitRequestModal,
     closeSubmitRequestModal,
+    approverConflictMessage,
+    closeApproverConflictModal,
     requestSignature,
     handleRequestSignature,
     handleSubmitRequest,

--- a/src/pages/HomePage/pages/Requisitions/pages/Request.tsx
+++ b/src/pages/HomePage/pages/Requisitions/pages/Request.tsx
@@ -59,6 +59,8 @@ const Request = () => {
     loading,
     handleAddSignature,
     closeModal,
+    approverConflictMessage,
+    closeApproverConflictModal,
     openSignature,
     imageChange,
     addingImage,
@@ -201,6 +203,34 @@ const Request = () => {
                           await submitForm();
                         }}
                       />
+                    </Modal>
+
+                    <Modal
+                      open={Boolean(approverConflictMessage)}
+                      onClose={closeApproverConflictModal}
+                      persist={false}
+                      className="max-w-lg"
+                    >
+                      <div className="space-y-4 p-6">
+                        <div>
+                          <p className="text-xs font-semibold uppercase tracking-wide text-primaryGray">
+                            Requisition cannot be submitted
+                          </p>
+                          <h3 className="mt-2 text-xl font-semibold text-primary">
+                            Approver and requester conflict
+                          </h3>
+                        </div>
+                        <p className="text-sm leading-6 text-primaryGray">
+                          {approverConflictMessage}
+                        </p>
+                        <div className="flex justify-end">
+                          <Button
+                            value="Got it"
+                            variant="default"
+                            onClick={closeApproverConflictModal}
+                          />
+                        </div>
+                      </div>
                     </Modal>
 
                     <RequisitionEditorFields

--- a/src/pages/HomePage/pages/Requisitions/pages/RequestDetails.tsx
+++ b/src/pages/HomePage/pages/Requisitions/pages/RequestDetails.tsx
@@ -93,6 +93,8 @@ const RequestDetails = () => {
     openSubmitRequestSignature,
     openSubmitRequestModal,
     closeSubmitRequestModal,
+    approverConflictMessage,
+    closeApproverConflictModal,
     requestSignature,
     handleRequestSignature,
     handleSubmitRequest,
@@ -268,8 +270,8 @@ const RequestDetails = () => {
       attachmentLists,
       products: rows.map((item) => ({
         name: item.name,
-        quantity: item.quantity,
-        unitPrice: item.amount,
+        quantity: Number(item.quantity || 0),
+        unitPrice: Number(item.amount || 0),
         image_url: item.image_url || undefined,
         image: item.image_url || undefined,
         id: item.id,
@@ -453,6 +455,33 @@ const RequestDetails = () => {
           loading={isSubmittingRequest}
           defaultSignature={requestSignature}
         />
+      </Modal>
+      <Modal
+        open={Boolean(approverConflictMessage)}
+        onClose={closeApproverConflictModal}
+        persist={false}
+        className="max-w-lg"
+      >
+        <div className="space-y-4 p-6">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wide text-primaryGray">
+              Requisition cannot be submitted
+            </p>
+            <h3 className="mt-2 text-xl font-semibold text-primary">
+              Approver and requester conflict
+            </h3>
+          </div>
+          <p className="text-sm leading-6 text-primaryGray">
+            {approverConflictMessage}
+          </p>
+          <div className="flex justify-end">
+            <Button
+              value="Got it"
+              variant="default"
+              onClick={closeApproverConflictModal}
+            />
+          </div>
+        </div>
       </Modal>
 
       <div className="space-y-5">

--- a/src/pages/HomePage/pages/Requisitions/requisitionStore/editableTableSlice.ts
+++ b/src/pages/HomePage/pages/Requisitions/requisitionStore/editableTableSlice.ts
@@ -19,8 +19,8 @@ const createEditableTableSlice = (
         ...state.rows,
         {
           name: "",
-          quantity: 0,
-          amount: 0,
+          quantity: "",
+          amount: "",
           total: 0,
           id: `${Date.now()}-${state.rows.length + 1}`,
           image_url: "",
@@ -36,7 +36,9 @@ const createEditableTableSlice = (
       const updatedRows = [...state.rows];
       const parsedValue =
         field === "quantity" || field === "amount"
-          ? parseFloat(value) || 0
+          ? value === ""
+            ? ""
+            : parseFloat(value) || 0
           : value;
 
       if (typeof parsedValue === "string") {
@@ -44,7 +46,8 @@ const createEditableTableSlice = (
       } else {
         updatedRows[index][field] = parsedValue as never;
         updatedRows[index].total =
-          updatedRows[index].quantity * updatedRows[index].amount;
+          Number(updatedRows[index].quantity || 0) *
+          Number(updatedRows[index].amount || 0);
       }
 
       return { rows: updatedRows };

--- a/src/pages/HomePage/pages/Requisitions/types/requestInterface.ts
+++ b/src/pages/HomePage/pages/Requisitions/types/requestInterface.ts
@@ -114,8 +114,8 @@ export interface IRequisitionDetails {
 
 export interface TableRow {
   name: string;
-  quantity: number;
-  amount: number;
+  quantity: number | "";
+  amount: number | "";
   total: number;
   id: string | number;
   image_url?: string;


### PR DESCRIPTION
Make SelectField clearable by default and add native/custom clear buttons; handle empty native select values as null and adjust padding/styling. Allow table row quantity/amount to be empty strings (number | ""); update formatting, parsing and total calculations in EditableTable and editableTableSlice to handle empty values. Add approver-requester conflict detection: introduce marker constant, capture ApiError messages in useAddRequisition/useRequisitionDetail, expose approverConflictMessage/closeApproverConflictModal, and show a modal in Request and RequestDetails when the conflict occurs. Also coerce row quantities/unitPrices to numbers on submission.

## Description
Describe the purpose of this pull request.

## Checklist
- [ ] Tests have been added to all functions
- [ ] Documentation has been updated
- [ ] Changes follow coding standards
