### PR TITLE
Add branch_id to position type and editing

### DIFF
--- a/src/pages/HomePage/pages/Settings/utils/useSettingsTabs.tsx
+++ b/src/pages/HomePage/pages/Settings/utils/useSettingsTabs.tsx
@@ -83,6 +83,7 @@ export function useSettingsTabs({
                   name: row.original?.name,
                   description: row.original?.description,
                   department_id: row.original?.department?.id,
+                  branch_id: row.original?.branch_id ?? undefined,
                 });
                 setEditMode(true);
                 setDisplayForm(true);

--- a/src/utils/api/settings/positionInterfaces.ts
+++ b/src/utils/api/settings/positionInterfaces.ts
@@ -2,5 +2,6 @@ export type PositionType = {
   id: number;
   name: string;
   description?: string;
+  branch_id?: number | null;
   department?: { id: number; name: string };
 }


### PR DESCRIPTION
Add branch_id field to PositionType interface and populate it when editing a position. This enables positions to be scoped to specific branches for multi-branch organization support.

## Description
Describe the purpose of this pull request.

## Checklist
- [ ] Tests have been added to all functions
- [ ] Documentation has been updated
- [ ] Changes follow coding standards
