### PR TITLE
Add Giving Options feature (frontend + API clients)

### DIFF
--- a/docs/GIVING_OPTIONS_BACKEND_CONTRACT.md
+++ b/docs/GIVING_OPTIONS_BACKEND_CONTRACT.md
@@ -1,0 +1,149 @@
+# Giving Options — Backend Contract
+
+Status: implemented (frontend + backend), phase 1 of 2.
+
+Phase 1 is configuration only: church admins define giving options, and each one
+gets a Paystack subaccount that payments will later be routed to. Phase 2 (donor
+checkout, webhooks, contribution records) is not built yet, but the fields it
+needs are already persisted.
+
+## Routing, not splitting
+
+Every giving option routes **100%** of its payments to its own settlement
+account. That is encoded as:
+
+- subaccount `percentage_charge` = `100`
+- stored `bearer` = `"subaccount"` — at transaction-init time, phase 2 must send
+  `bearer: "subaccount"` so the Paystack fee is deducted from the giving option's
+  share rather than from a main account that receives nothing.
+
+There is deliberately **no percentage field in the UI**. Nothing is split.
+
+Do not confuse this with `bankAccountConfig.percentage`, which is an unrelated
+finance-reporting allocation capped at 100% org-wide. The two never interact.
+
+## Data model
+
+`givingOption` (MySQL, migration `20260727120000_add_giving_options`):
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | `VARCHAR(191)` | cuid, matches the other finance configs |
+| `name` | `VARCHAR(191)` | unique per branch **among non-archived rows** (enforced in the service, not the DB) |
+| `description` | `TEXT?` | |
+| `currency` | `VARCHAR(191)` | defaults `GHS` |
+| `account_type` | `VARCHAR(191)` | `ghipss` or `mobile_money` |
+| `settlement_bank` | `VARCHAR(191)` | Paystack bank/provider **code** |
+| `bank_name` | `VARCHAR(191)` | denormalized label, so lists render without hitting Paystack |
+| `account_number` | `VARCHAR(191)` | 5–20 digits |
+| `account_name` | `VARCHAR(191)` | |
+| `subaccount_code` | `VARCHAR(191)?` unique | Paystack `ACCT_xxx` |
+| `percentage_charge` | `DOUBLE` | always `100` |
+| `bearer` | `VARCHAR(191)` | always `subaccount` |
+| `is_active` | `BOOLEAN` | |
+| `archived_at` | `DATETIME?` | non-null ⇒ soft-deleted |
+| `paystack_synced_at` | `DATETIME?` | **null ⇒ local state and Paystack have drifted** |
+| `branch_id` | `INT?` | FK → `branch`, `ON DELETE SET NULL` |
+| `created_by` | `INT?` | user id, intentionally no FK |
+
+`created_by` has no foreign key: it is an audit breadcrumb, and a deleted user
+should not be able to block or cascade into financial configuration.
+
+## Endpoints
+
+Base: `/givingoption`. All routes require a bearer token.
+
+| Method | Path | Permission | Notes |
+|---|---|---|---|
+| POST | `/create-giving-option` | `Giving:manage` | Creates the Paystack subaccount, then the row |
+| GET | `/get-giving-options` | `Giving:view` | `page`, `take`, `branch_id`, `include_archived` |
+| GET | `/:id` | `Giving:view` | |
+| PUT | `/update-giving-option?id=` | `Giving:manage` | Syncs the subaccount |
+| PUT | `/restore-giving-option?id=` | `Giving:manage` | |
+| DELETE | `/delete-giving-option?id=` | `Giving:admin` | Archive (soft delete) |
+| GET | `/banks?currency=GHS` | `Giving:manage` | Server-side proxy, cached 24h |
+| GET | `/resolve-account?account_number=&bank_code=` | `Giving:manage` | Best effort; `data` may be `null` |
+
+List and mutation responses follow the existing finance envelope
+(`{ message, data, current_page, take, total, page_size, totalPages }`).
+
+Every row is returned with two derived fields the frontend relies on:
+`masked_account_number` (`••••1234`) and `is_synced` (`paystack_synced_at !== null`).
+
+### Error semantics
+
+| Status | Meaning |
+|---|---|
+| 409 | Name already used by an active option in that branch, or the option is archived and must be restored before editing |
+| 422 | Validation failure, **or** Paystack rejected the request (its message is passed through verbatim) |
+| 502 | Paystack unreachable or returned 5xx |
+| 500 | `PAYSTACK_SECRET_KEY` not configured on the server |
+
+## Write ordering and compensation
+
+Paystack has no `DELETE /subaccount` endpoint. Only create, update (including
+`active: false`), fetch, and list. Everything below follows from that.
+
+- **Create** — Paystack first, then the DB. An option with no live subaccount
+  cannot receive money, so persisting one would be a lie. If the insert then
+  fails, the new subaccount is deactivated so it cannot quietly collect
+  payments with no local record behind it.
+- **Update** — Paystack first, then the DB, so a settlement account Paystack
+  rejects is never persisted as accepted. If the DB write fails afterwards, the
+  subaccount is rolled back to the values the DB still believes.
+- **Update, self-heal** — a row whose `subaccount_code` is null gets a fresh
+  subaccount instead of remaining permanently unable to receive payments.
+- **Archive** — the local archive is authoritative: a hidden option can never be
+  chosen at checkout. So archiving **succeeds even when Paystack is
+  unreachable**; `paystack_synced_at` is cleared, the response message says the
+  option needs re-syncing, and the card shows a warning.
+- **Restore** — strict, and deliberately asymmetric with archive. An option
+  visible in the UI must actually be able to receive money, so a Paystack
+  failure aborts the restore with 502.
+
+Any row with `paystack_synced_at = null` is a known-drift record. Re-saving it
+re-syncs it.
+
+## Credentials
+
+`resolvePaystackCredentials(branchId)` in
+`Backend/src/libs/paystack/paystackCredentials.ts` is the **only** place that
+reads `PAYSTACK_SECRET_KEY` for this feature. Today it ignores `branchId` and
+returns the org-wide env key.
+
+Per-branch keys are a planned change, and this is the single seam for it: look
+the branch's credential up, fall back to the env key, return the same shape.
+No other file changes. Nothing else may read the env var directly, and the key
+is never returned to the browser — that is why the bank list is proxied rather
+than fetched client-side.
+
+Env:
+
+```
+PAYSTACK_SECRET_KEY=sk_test_xxx     # already used by the marketplace orders module
+PAYSTACK_BASE_URL=                  # optional; defaults to https://api.paystack.co
+```
+
+## Permissions
+
+New canonical domain `Giving`, actions `view` / `manage` / `admin`, group
+Administration, optional. Aliases: `Giving_Options`, `Giving Options`.
+
+Existing access levels have no `Giving` key, so the domain falls back to
+`Financials` on both sides — `PERMISSION_KEY_ALIASES` in
+`Backend/src/middleWare/authorization.ts` and `DOMAIN_FALLBACKS` in
+`Frontend/src/utils/accessControl.ts`. Consequence worth being explicit about:
+**until an admin sets `Giving` explicitly, anyone who can manage Financials can
+manage giving options.** No data backfill is required, and nobody is locked out
+by the deploy. Setting `Giving` on an access level always overrides the fallback,
+including setting it to `No_Access`.
+
+## Phase 2 hooks (not built)
+
+What phase 2 needs that already exists: `subaccount_code`, `bearer`,
+`percentage_charge`, `currency`, `is_active`/`archived_at`. What it still needs:
+a transaction table keyed by `giving_option_id`, a webhook route with signature
+verification, and `POST /transaction/initialize` passing
+`subaccount: <subaccount_code>` and `bearer: "subaccount"`.
+
+Only non-archived options may be offered at checkout.

--- a/src/pages/HomePage/pages/FinanceManagement/GivingOptions/GivingOptionsOverview.tsx
+++ b/src/pages/HomePage/pages/FinanceManagement/GivingOptions/GivingOptionsOverview.tsx
@@ -1,0 +1,146 @@
+import { Modal } from "@/components/Modal";
+import { useDelete } from "@/CustomHooks/useDelete";
+import { useFetch } from "@/CustomHooks/useFetch";
+import PageHeader from "@/pages/HomePage/Components/PageHeader";
+import { showDeleteDialog, showNotification } from "@/pages/HomePage/utils";
+import { api } from "@/utils";
+import type { GivingOption } from "@/utils/api/finance/interface";
+import { cn } from "@/utils/cn";
+import React from "react";
+import GivingOptionCard from "./components/GivingOptionCard";
+import GivingOptionForm from "./components/GivingOptionForm";
+
+type StatusFilter = "active" | "archived";
+
+const GivingOptionsOverview = () => {
+  const [openModal, setOpenModal] = React.useState(false);
+  const [selectedOption, setSelectedOption] =
+    React.useState<GivingOption | null>(null);
+  const [statusFilter, setStatusFilter] =
+    React.useState<StatusFilter>("active");
+
+  // Archived rows are only ever fetched when the archived tab is showing, so the
+  // default view stays a plain list of live options.
+  const { data, loading, refetch } = useFetch(api.fetch.fetchGivingOptions, {
+    include_archived: statusFilter === "archived" ? "true" : "false",
+  });
+
+  const { executeDelete, success } = useDelete(api.delete.archiveGivingOption);
+
+  const givingOptions = React.useMemo<GivingOption[]>(() => {
+    const rows = Array.isArray(data?.data) ? data.data : [];
+
+    return statusFilter === "archived"
+      ? rows.filter((option) => Boolean(option.archived_at))
+      : rows.filter((option) => !option.archived_at);
+  }, [data, statusFilter]);
+
+  const closeModal = () => {
+    setOpenModal(false);
+    setSelectedOption(null);
+  };
+
+  const handleArchive = async (id: string | number) => {
+    await executeDelete({ id: String(id) });
+  };
+
+  const handleRestore = async (option: GivingOption) => {
+    try {
+      await api.put.restoreGivingOption({}, { id: option.id });
+      showNotification("Giving option restored successfully", "success");
+      await refetch();
+    } catch (error) {
+      const message =
+        typeof error === "object" && error !== null && "response" in error
+          ? (error as { response?: { data?: { message?: string } } }).response
+              ?.data?.message
+          : undefined;
+
+      showNotification(
+        message || "Unable to restore the giving option",
+        "error"
+      );
+    }
+  };
+
+  React.useEffect(() => {
+    if (success) {
+      refetch();
+      showNotification("Giving option archived successfully", "success");
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [success]);
+
+  return (
+    <div className="space-y-4">
+      <PageHeader
+        title="Manage Giving Options"
+        buttonValue="Create giving option"
+        onClick={() => {
+          setSelectedOption(null);
+          setOpenModal(true);
+        }}
+      />
+
+      <div className="flex gap-2">
+        {(["active", "archived"] as StatusFilter[]).map((filter) => (
+          <button
+            key={filter}
+            type="button"
+            onClick={() => setStatusFilter(filter)}
+            className={cn(
+              "rounded-full px-4 py-1.5 text-sm font-medium capitalize transition-colors",
+              statusFilter === filter
+                ? "bg-primary text-white"
+                : "bg-lightGray/40 text-primaryGray hover:bg-lightGray/70"
+            )}
+          >
+            {filter}
+          </button>
+        ))}
+      </div>
+
+      {loading ? (
+        <p className="rounded-lg bg-lightGray/30 px-4 py-6 text-sm text-primaryGray">
+          Loading giving options...
+        </p>
+      ) : givingOptions.length === 0 ? (
+        <p className="rounded-lg bg-lightGray/30 px-4 py-6 text-sm text-primaryGray">
+          {statusFilter === "archived"
+            ? "No archived giving options."
+            : "No giving options yet. Create one to start collecting through Paystack."}
+        </p>
+      ) : (
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+          {givingOptions.map((option) => (
+            <GivingOptionCard
+              key={option.id}
+              givingOption={option}
+              onEdit={() => {
+                setSelectedOption(option);
+                setOpenModal(true);
+              }}
+              onArchive={() =>
+                showDeleteDialog(
+                  { name: option.name, id: option.id },
+                  handleArchive
+                )
+              }
+              onRestore={() => handleRestore(option)}
+            />
+          ))}
+        </div>
+      )}
+
+      <Modal open={openModal} onClose={closeModal} className="max-w-2xl">
+        <GivingOptionForm
+          onClose={closeModal}
+          onSaved={refetch}
+          initialData={selectedOption ?? undefined}
+        />
+      </Modal>
+    </div>
+  );
+};
+
+export default GivingOptionsOverview;

--- a/src/pages/HomePage/pages/FinanceManagement/GivingOptions/components/GivingOptionCard.tsx
+++ b/src/pages/HomePage/pages/FinanceManagement/GivingOptions/components/GivingOptionCard.tsx
@@ -1,0 +1,101 @@
+import {
+  ArrowPathIcon,
+  ExclamationTriangleIcon,
+  PencilSquareIcon,
+  TrashIcon,
+} from "@heroicons/react/24/outline";
+import { useRouteAccess } from "@/context/RouteAccessContext";
+import type { GivingOption } from "@/utils/api/finance/interface";
+
+interface IProps {
+  givingOption: GivingOption;
+  onEdit?: () => void;
+  onArchive?: () => void;
+  onRestore?: () => void;
+}
+
+const GivingOptionCard = ({
+  givingOption,
+  onEdit,
+  onArchive,
+  onRestore,
+}: IProps) => {
+  const { canManageCurrentRoute } = useRouteAccess();
+  const isArchived = Boolean(givingOption.archived_at);
+
+  return (
+    <div className="app-card relative space-y-3">
+      <div className="flex items-start justify-between gap-3">
+        <div className="space-y-1">
+          <p className="text-base font-semibold text-primary">
+            {givingOption.name}
+          </p>
+          <span
+            className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${
+              isArchived
+                ? "bg-lightGray text-primaryGray"
+                : "bg-green-100 text-green-700"
+            }`}
+          >
+            {isArchived ? "Archived" : "Active"}
+          </span>
+        </div>
+
+        <div className="flex gap-2">
+          {!isArchived && onEdit && canManageCurrentRoute && (
+            <button
+              onClick={onEdit}
+              className="app-icon-btn"
+              aria-label={`Edit ${givingOption.name}`}
+            >
+              <PencilSquareIcon className="h-4 w-4 text-gray-700" />
+            </button>
+          )}
+          {!isArchived && onArchive && canManageCurrentRoute && (
+            <button
+              onClick={onArchive}
+              className="app-icon-btn app-icon-btn-danger"
+              aria-label={`Archive ${givingOption.name}`}
+            >
+              <TrashIcon className="h-4 w-4 text-red-600" />
+            </button>
+          )}
+          {isArchived && onRestore && canManageCurrentRoute && (
+            <button
+              onClick={onRestore}
+              className="app-icon-btn"
+              aria-label={`Restore ${givingOption.name}`}
+            >
+              <ArrowPathIcon className="h-4 w-4 text-gray-700" />
+            </button>
+          )}
+        </div>
+      </div>
+
+      <p className="text-sm text-primaryGray">
+        {givingOption.description || "No description available."}
+      </p>
+
+      <div className="space-y-1 text-sm text-primary">
+        <p className="font-medium">{givingOption.bank_name}</p>
+        <p className="text-primaryGray">
+          {givingOption.masked_account_number} &middot;{" "}
+          {givingOption.account_name}
+        </p>
+      </div>
+
+      <p className="text-xs text-primaryGray">
+        Routes 100% of payments to this account ({givingOption.currency})
+      </p>
+
+      {!givingOption.is_synced && (
+        <p className="flex items-start gap-1.5 text-xs font-medium text-amber-600">
+          <ExclamationTriangleIcon className="mt-0.5 h-4 w-4 shrink-0" />
+          Not in sync with Paystack. Save this option again to re-sync it.
+        </p>
+      )}
+    </div>
+  );
+};
+
+export default GivingOptionCard;

--- a/src/pages/HomePage/pages/FinanceManagement/GivingOptions/components/GivingOptionForm.tsx
+++ b/src/pages/HomePage/pages/FinanceManagement/GivingOptions/components/GivingOptionForm.tsx
@@ -1,0 +1,297 @@
+import { Button } from "@/components";
+import { BranchSelectField } from "@/components/BranchSelectField";
+import { FormikInputDiv } from "@/components/FormikInputDiv";
+import FormikSelectField from "@/components/FormikSelect";
+import { FormHeader, FormLayout } from "@/components/ui";
+import { useFetch } from "@/CustomHooks/useFetch";
+import { showNotification } from "@/pages/HomePage/utils";
+import { ALL_BRANCHES, useBranchStore } from "@/store/useBranchStore";
+import { api } from "@/utils/api/apiCalls";
+import type {
+  GivingOption,
+  GivingOptionPayload,
+} from "@/utils/api/finance/interface";
+import { Field, Form, Formik } from "formik";
+import { useMemo, useState } from "react";
+import {
+  givingOptionSchema,
+  type GivingOptionFormValues,
+} from "../utils/givingOptionSchema";
+
+interface IProps {
+  onClose: () => void;
+  onSaved: () => void | Promise<unknown>;
+  initialData?: GivingOption;
+}
+
+const ACCOUNT_TYPE_OPTIONS = [
+  { value: "ghipss", label: "Bank account" },
+  { value: "mobile_money", label: "Mobile money" },
+];
+
+const CURRENCY = "GHS";
+
+const extractErrorMessage = (error: unknown, fallback: string): string => {
+  if (typeof error === "object" && error !== null && "response" in error) {
+    const response = (error as { response?: { data?: { message?: string } } })
+      .response;
+    if (response?.data?.message) return response.data.message;
+  }
+
+  return error instanceof Error ? error.message : fallback;
+};
+
+const GivingOptionForm = ({ onClose, onSaved, initialData }: IProps) => {
+  const activeBranchId = useBranchStore((state) => state.activeBranchId);
+  const [submitting, setSubmitting] = useState(false);
+  const [resolving, setResolving] = useState(false);
+
+  const { data: banksResponse, loading: banksLoading } = useFetch(
+    api.fetch.fetchPaystackBanks,
+    { currency: CURRENCY }
+  );
+
+  const banks = useMemo(
+    () => (Array.isArray(banksResponse?.data) ? banksResponse.data : []),
+    [banksResponse]
+  );
+
+  const handleSubmit = async (values: GivingOptionFormValues) => {
+    if (activeBranchId === ALL_BRANCHES && !values.branch_id) {
+      return;
+    }
+
+    const bank = banks.find((item) => item.code === values.settlement_bank);
+
+    if (!bank) {
+      showNotification("Select a bank or mobile money provider", "error");
+      return;
+    }
+
+    const payload: GivingOptionPayload = {
+      name: values.name.trim(),
+      ...(values.description.trim() && {
+        description: values.description.trim(),
+      }),
+      account_type: values.account_type,
+      settlement_bank: bank.code,
+      bank_name: bank.name,
+      account_number: values.account_number.trim(),
+      account_name: values.account_name.trim(),
+      currency: CURRENCY,
+      ...(values.branch_id !== "" && { branch_id: Number(values.branch_id) }),
+    };
+
+    setSubmitting(true);
+
+    try {
+      // Called directly rather than through usePost/usePut so a Paystack
+      // rejection keeps the modal open with its message, instead of closing as
+      // though the subaccount had been created.
+      if (initialData?.id) {
+        await api.put.updateGivingOption(payload, { id: initialData.id });
+        showNotification("Giving option updated successfully", "success");
+      } else {
+        await api.post.createGivingOption(payload);
+        showNotification("Giving option created successfully", "success");
+      }
+
+      await onSaved();
+      onClose();
+    } catch (error) {
+      showNotification(
+        extractErrorMessage(error, "Unable to save the giving option"),
+        "error"
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div>
+      <FormHeader>
+        {initialData ? "Edit giving option" : "Create giving option"}
+      </FormHeader>
+
+      <Formik<GivingOptionFormValues>
+        initialValues={{
+          name: initialData?.name ?? "",
+          description: initialData?.description ?? "",
+          account_type: initialData?.account_type ?? "ghipss",
+          settlement_bank: initialData?.settlement_bank ?? "",
+          account_number: initialData?.account_number ?? "",
+          account_name: initialData?.account_name ?? "",
+          branch_id: initialData?.branch_id ?? ("" as number | ""),
+        }}
+        validationSchema={givingOptionSchema}
+        enableReinitialize
+        onSubmit={handleSubmit}
+      >
+        {({ values, setFieldValue, submitCount, handleBlur }) => {
+          const bankOptions = banks
+            .filter((bank) =>
+              values.account_type === "mobile_money"
+                ? bank.type === "mobile_money"
+                : bank.type !== "mobile_money"
+            )
+            .map((bank) => ({ value: bank.code, label: bank.name }));
+
+          /**
+           * Convenience only. Paystack's resolve endpoint has patchy coverage in
+           * Ghana, so a miss is silent and the typed name stands.
+           */
+          const tryResolveAccountName = async () => {
+            const accountNumber = values.account_number.trim();
+
+            if (!values.settlement_bank || !/^[0-9]{5,20}$/.test(accountNumber)) {
+              return;
+            }
+
+            setResolving(true);
+
+            try {
+              const response = await api.fetch.resolveBankAccount({
+                account_number: accountNumber,
+                bank_code: values.settlement_bank,
+              });
+
+              if (response?.data?.account_name) {
+                setFieldValue("account_name", response.data.account_name);
+              }
+            } catch {
+              // Deliberately silent — the field stays editable.
+            } finally {
+              setResolving(false);
+            }
+          };
+
+          return (
+            <Form className="space-y-6 px-5 pb-5 pt-5">
+              <FormLayout $columns={1}>
+                <BranchSelectField
+                  value={values.branch_id ?? ""}
+                  onChange={(v) => setFieldValue("branch_id", v)}
+                  required
+                  error={
+                    submitCount > 0 &&
+                    activeBranchId === ALL_BRANCHES &&
+                    !values.branch_id
+                      ? "Branch is required"
+                      : undefined
+                  }
+                />
+
+                <Field
+                  component={FormikInputDiv}
+                  label="Name *"
+                  placeholder="e.g. Building Fund"
+                  id="name"
+                  name="name"
+                />
+
+                <Field
+                  component={FormikInputDiv}
+                  type="textarea"
+                  label="Description"
+                  placeholder="What is this giving option for?"
+                  id="description"
+                  name="description"
+                />
+
+                <Field
+                  component={FormikSelectField}
+                  label="Settlement account type *"
+                  id="account_type"
+                  name="account_type"
+                  options={ACCOUNT_TYPE_OPTIONS}
+                  onChange={(_name: string, value: string | number | null) => {
+                    setFieldValue("account_type", value ?? "ghipss");
+                    // Bank codes are not shared between the two lists.
+                    setFieldValue("settlement_bank", "");
+                  }}
+                />
+
+                <Field
+                  component={FormikSelectField}
+                  label={
+                    values.account_type === "mobile_money"
+                      ? "Mobile money provider *"
+                      : "Bank *"
+                  }
+                  id="settlement_bank"
+                  name="settlement_bank"
+                  options={bankOptions}
+                  searchable
+                  searchPlaceholder="Search"
+                  placeholder={
+                    banksLoading ? "Loading providers..." : "Select"
+                  }
+                  disabled={banksLoading || bankOptions.length === 0}
+                  helperText={
+                    !banksLoading && bankOptions.length === 0
+                      ? "Could not load the list from Paystack. Check the server's Paystack configuration."
+                      : undefined
+                  }
+                />
+
+                <Field
+                  component={FormikInputDiv}
+                  label={
+                    values.account_type === "mobile_money"
+                      ? "Mobile money number *"
+                      : "Account number *"
+                  }
+                  placeholder="Enter the settlement account number"
+                  id="account_number"
+                  name="account_number"
+                  onBlur={(
+                    event: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>
+                  ) => {
+                    // Keep Formik's own blur handling; the lookup is additive.
+                    handleBlur(event);
+                    void tryResolveAccountName();
+                  }}
+                />
+
+                <Field
+                  component={FormikInputDiv}
+                  label="Account name *"
+                  placeholder={
+                    resolving ? "Looking up account name..." : "Account holder name"
+                  }
+                  id="account_name"
+                  name="account_name"
+                />
+              </FormLayout>
+
+              <p className="rounded-lg bg-lightGray/30 px-4 py-3 text-xs text-primaryGray">
+                Payments made to this giving option are routed in full to this
+                account. Paystack transaction fees are deducted from it, and no
+                portion is split to any other account.
+              </p>
+
+              <div className="flex justify-end gap-2">
+                <Button
+                  value="Close"
+                  variant="secondary"
+                  type="button"
+                  onClick={onClose}
+                />
+                <Button
+                  value={initialData ? "Update" : "Save"}
+                  variant="primary"
+                  type="submit"
+                  disabled={submitting}
+                  loading={submitting}
+                />
+              </div>
+            </Form>
+          );
+        }}
+      </Formik>
+    </div>
+  );
+};
+
+export default GivingOptionForm;

--- a/src/pages/HomePage/pages/FinanceManagement/GivingOptions/utils/givingOptionSchema.ts
+++ b/src/pages/HomePage/pages/FinanceManagement/GivingOptions/utils/givingOptionSchema.ts
@@ -1,0 +1,28 @@
+import * as Yup from "yup";
+
+export const givingOptionSchema = Yup.object({
+  name: Yup.string()
+    .trim()
+    .required("Name is required")
+    .max(120, "Name must be 120 characters or fewer"),
+  description: Yup.string().trim().max(500, "Description is too long"),
+  account_type: Yup.string()
+    .oneOf(["ghipss", "mobile_money"], "Select a valid account type")
+    .required("Account type is required"),
+  settlement_bank: Yup.string().trim().required("Bank or provider is required"),
+  account_number: Yup.string()
+    .trim()
+    .matches(/^[0-9]{5,20}$/, "Account number must be 5 to 20 digits")
+    .required("Account number is required"),
+  account_name: Yup.string().trim().required("Account name is required"),
+});
+
+export type GivingOptionFormValues = {
+  name: string;
+  description: string;
+  account_type: "ghipss" | "mobile_money";
+  settlement_bank: string;
+  account_number: string;
+  account_name: string;
+  branch_id: number | "";
+};

--- a/src/routes/appRoutes.tsx
+++ b/src/routes/appRoutes.tsx
@@ -97,6 +97,7 @@ import FinanceManager from "@/pages/HomePage/pages/FinanceManagement/FinanaceMan
 import FinanceDetailPage from "@/pages/HomePage/pages/FinanceManagement/pages/FinanceDetailPage.js";
 import FianancialsForm from "@/pages/HomePage/pages/FinanceManagement/pages/FinancialsForm.js";
 import FinanceConfiguration from "@/pages/HomePage/pages/FinanceManagement/pages/FinanceConfiguration.js";
+import GivingOptionsOverview from "@/pages/HomePage/pages/FinanceManagement/GivingOptions/GivingOptionsOverview";
 import PledgesOverview from "@/pages/HomePage/pages/FinanceManagement/Pledges/PledgesOverview";
 import PledgeForm from "@/pages/HomePage/pages/FinanceManagement/Pledges/PledgeForm";
 import PledgeDetail from "@/pages/HomePage/pages/FinanceManagement/Pledges/PledgeDetail";
@@ -692,6 +693,14 @@ export const routes: AppRoute[] = [
             element: <FinanceConfiguration />,
             isPrivate: true,
             permissionNeeded: "manage_financials",
+            sideTab: true,
+          },
+          {
+            path: "giving-options",
+            name: "Manage Giving Options",
+            element: <GivingOptionsOverview />,
+            isPrivate: true,
+            permissionNeeded: "view_giving",
             sideTab: true,
           },
           {

--- a/src/utils/accessControl.ts
+++ b/src/utils/accessControl.ts
@@ -26,6 +26,7 @@ export const CANONICAL_PERMISSION_DOMAINS = [
   "Church_Attendance",
   "Theme",
   "Financials",
+  "Giving",
   "Pledges",
   "Marketplace",
   "School_of_ministry",
@@ -89,6 +90,7 @@ const DOMAIN_ALIASES: Record<PermissionDomain, string[]> = {
     "School of Ministry",
   ],
   Financials: ["Financials", "Finance", "Finances"],
+  Giving: ["Giving", "Giving_Options", "Giving Options"],
   Pledges: ["Pledges", "Pledge"],
   Settings: ["Settings", "Setting"],
   AI: ["AI", "Ai", "Artificial Intelligence"],
@@ -103,6 +105,9 @@ const DOMAIN_ALIASES: Record<PermissionDomain, string[]> = {
 // domains, not aliases — aliases feed DOMAIN_LOOKUP and would remap incoming keys.
 const DOMAIN_FALLBACKS: Partial<Record<PermissionDomain, PermissionDomain[]>> = {
   Membership_Management: ["Members"],
+  // Giving shipped after access levels were saved, so anyone who already
+  // administers Financials keeps working until Giving is set explicitly.
+  Giving: ["Financials"],
 };
 
 const REQUIRED_KEYS_ON_MUTATION = new Set<PermissionDomain>([
@@ -254,6 +259,13 @@ export const ACCESS_LEVEL_DOMAINS: DomainMeta[] = [
     required: false,
   },
   {
+    key: "Giving",
+    label: "Giving Options",
+    description: "Giving options and the accounts their payments are routed to",
+    group: "Administration",
+    required: false,
+  },
+  {
     key: "Pledges",
     label: "Pledges",
     description: "Pledge campaigns, pledgers and redemptions",
@@ -320,6 +332,9 @@ const LEGACY_PERMISSION_TO_REQUIREMENT: Record<string, PermissionRequirementObje
   manage_theme: { domain: "Theme", action: "manage" },
   view_financials: { domain: "Financials", action: "view" },
   manage_financials: { domain: "Financials", action: "manage" },
+  view_giving: { domain: "Giving", action: "view" },
+  manage_giving: { domain: "Giving", action: "manage" },
+  delete_giving: { domain: "Giving", action: "admin" },
   view_pledges: { domain: "Pledges", action: "view" },
   manage_pledges: { domain: "Pledges", action: "manage" },
   delete_pledges: { domain: "Pledges", action: "admin" },

--- a/src/utils/api/apiDelete.ts
+++ b/src/utils/api/apiDelete.ts
@@ -212,6 +212,13 @@ export class ApiDeletionCalls {
     return this.deleteFromApi<void>("bankaccountconfig/delete-bank-account-config", query);
   };
 
+  // archive giving option (soft delete; deactivates the Paystack subaccount)
+  archiveGivingOption = (
+    query: QueryType
+  ): Promise<ApiResponse<void>> => {
+    return this.deleteFromApi<void>("givingoption/delete-giving-option", query);
+  };
+
   // delete tithe breakdown config
   deleteTitheBreakdownConfig = (
     query: QueryType

--- a/src/utils/api/apiFetch.ts
+++ b/src/utils/api/apiFetch.ts
@@ -67,6 +67,9 @@ import type {
   FinanceApprovalConfig,
   FinanceData,
   FinancialRecord,
+  GivingOption,
+  PaystackBank,
+  ResolvedBankAccount,
 } from "./finance/interface";
 import type {
   ApprovalConfig,
@@ -748,6 +751,34 @@ export class ApiCalls {
     query?: QueryType
   ): Promise<ApiResponse<unknown>> => {
     return this.fetchFromApi("bankaccountconfig/get-bank-account-configs", query);
+  };
+
+  // fetch giving options
+  fetchGivingOptions = (
+    query?: QueryType
+  ): Promise<ApiResponse<GivingOption[]>> => {
+    return this.fetchFromApi("givingoption/get-giving-options", query);
+  };
+
+  // fetch a single giving option
+  fetchGivingOption = (
+    query?: QueryType
+  ): Promise<ApiResponse<GivingOption>> => {
+    return this.fetchFromApi(`givingoption/${query?.id ?? ""}`);
+  };
+
+  // fetch Paystack banks and mobile money providers (proxied server-side)
+  fetchPaystackBanks = (
+    query?: QueryType
+  ): Promise<ApiResponse<PaystackBank[]>> => {
+    return this.fetchFromApi("givingoption/banks", query);
+  };
+
+  // best-effort account name lookup; data is null when Paystack cannot resolve it
+  resolveBankAccount = (
+    query?: QueryType
+  ): Promise<ApiResponse<ResolvedBankAccount | null>> => {
+    return this.fetchFromApi("givingoption/resolve-account", query);
   };
 
   // fetch tithe breakdown config

--- a/src/utils/api/apiPost.ts
+++ b/src/utils/api/apiPost.ts
@@ -71,6 +71,8 @@ import type {
   FinanceApprovalConfig,
   FinanceMutationRequest,
   FinancialRecord,
+  GivingOption,
+  GivingOptionPayload,
 } from "./finance/interface";
 import type {
   ApprovalConfig,
@@ -582,6 +584,13 @@ export class ApiCreationCalls {
     payload: unknown
   ): Promise<ApiResponse<unknown>> => {
     return this.postToApi("bankaccountconfig/create-bank-account-config", payload);
+  };
+
+  // create giving option (also creates its Paystack subaccount)
+  createGivingOption = (
+    payload: GivingOptionPayload
+  ): Promise<ApiResponse<GivingOption>> => {
+    return this.postToApi("givingoption/create-giving-option", payload);
   };
 
   // create tithe breakdown config

--- a/src/utils/api/apiPut.ts
+++ b/src/utils/api/apiPut.ts
@@ -41,6 +41,8 @@ import type {
 import type {
   FinanceMutationRequest,
   FinancialRecord,
+  GivingOption,
+  GivingOptionPayload,
 } from "./finance/interface";
 import type { UpdateNotificationPreferencePayload } from "./notifications/interfaces";
 import type {
@@ -529,6 +531,30 @@ export class ApiUpdateCalls {
   ): Promise<ApiResponse<unknown>> => {
     return this.apiExecution.updateData(
       "bankaccountconfig/update-bank-account-config",
+      payload,
+      query
+    );
+  };
+
+  // update giving option (syncs the Paystack subaccount)
+  updateGivingOption = (
+    payload: GivingOptionPayload,
+    query?: QueryType
+  ): Promise<ApiResponse<GivingOption>> => {
+    return this.apiExecution.updateData(
+      "givingoption/update-giving-option",
+      payload,
+      query
+    );
+  };
+
+  // restore an archived giving option
+  restoreGivingOption = (
+    payload: unknown,
+    query?: QueryType
+  ): Promise<ApiResponse<GivingOption>> => {
+    return this.apiExecution.updateData(
+      "givingoption/restore-giving-option",
       payload,
       query
     );

--- a/src/utils/api/branchScope.ts
+++ b/src/utils/api/branchScope.ts
@@ -46,6 +46,7 @@ const BRANCH_SCOPED_ENDPOINTS = [
   "receiptconfig/",
   "paymentconfig/",
   "bankaccountconfig/",
+  "givingoption/",
   "tithebreakdownconfig/",
   "financials/",
 ] as const;

--- a/src/utils/api/finance/interface.ts
+++ b/src/utils/api/finance/interface.ts
@@ -69,3 +69,56 @@ export interface FinancialListPayload {
 export type FinanceMutationRequest = FinanceData & {
   action: FinanceSaveAction;
 };
+
+export type GivingAccountType = "ghipss" | "mobile_money";
+
+export interface GivingOption {
+  id: string;
+  name: string;
+  description: string | null;
+  currency: string;
+  account_type: GivingAccountType;
+  /** Paystack bank or mobile money provider code */
+  settlement_bank: string;
+  bank_name: string;
+  account_number: string;
+  account_name: string;
+  masked_account_number: string;
+  subaccount_code: string | null;
+  /** Always 100 — payments are routed to this account, never split */
+  percentage_charge: number;
+  bearer: string;
+  is_active: boolean;
+  archived_at: string | null;
+  paystack_synced_at: string | null;
+  /** False when local state and Paystack are known to have drifted */
+  is_synced: boolean;
+  branch_id: number | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface GivingOptionPayload {
+  name: string;
+  description?: string;
+  account_type: GivingAccountType;
+  settlement_bank: string;
+  bank_name: string;
+  account_number: string;
+  account_name: string;
+  currency?: string;
+  branch_id?: number;
+}
+
+export interface PaystackBank {
+  name: string;
+  code: string;
+  type: string;
+  currency: string;
+  active: boolean;
+}
+
+export interface ResolvedBankAccount {
+  account_number: string;
+  account_name: string;
+}


### PR DESCRIPTION
Introduce the Giving Options feature (phase 1: configuration) across the frontend and API clients. Adds backend contract doc (docs/GIVING_OPTIONS_BACKEND_CONTRACT.md), UI pages/components (GivingOptionsOverview, GivingOptionCard, GivingOptionForm) and validation schema. Extends API client with create/fetch/update/restore/archive endpoints and paystack helpers, includes branch-scoped endpoint registration. Adds Giving types to finance interfaces and wires permission support (Giving domain, aliases, fallback to Financials, and legacy permission mappings). Registers the route under FinanceManagement.

## Description
Describe the purpose of this pull request.

## Checklist
- [ ] Tests have been added to all functions
- [ ] Documentation has been updated
- [ ] Changes follow coding standards
