### PR TITLE
Add delivery status & update flow for orders

### DIFF
--- a/src/pages/HomePage/pages/MarketPlace/components/Orders/MarketOrders.tsx
+++ b/src/pages/HomePage/pages/MarketPlace/components/Orders/MarketOrders.tsx
@@ -1,12 +1,20 @@
 import { useFetch } from "@/CustomHooks/useFetch";
+import { usePut } from "@/CustomHooks/usePut";
 import { Orders } from "./Orders";
 import { api, IOrders } from "@/utils";
 import { useParams } from "react-router-dom";
 import { decodeQuery } from "@/pages/HomePage/utils";
 import { getBaseOrderColumns } from "./OrdersTableColumns";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Button } from "@/components";
 import { showNotification } from "@/pages/HomePage/utils";
+
+const DELIVERY_STATUS_OPTIONS: IOrders["delivery_status"][] = [
+  "pending",
+  "shipped",
+  "delivered",
+  "cancelled",
+];
 
 const getOrderTimestamp = (order: IOrders) => {
   return order.created_at || order.order_created_at || order.ordered_at || "";
@@ -32,6 +40,47 @@ export function MarketOrders() {
   const market_id = decodeQuery(String(id));
   const { data, refetch } = useFetch(api.fetch.fetchOrdersByMarket, { market_id });
   const [isReconciling, setIsReconciling] = useState(false);
+  const [updatingOrderId, setUpdatingOrderId] = useState<string | null>(null);
+
+  const {
+    data: deliveryStatusResponse,
+    error: deliveryStatusError,
+    loading: isUpdatingDeliveryStatus,
+    updateData: updateDeliveryStatus,
+  } = usePut(api.put.updateOrderDeliveryStatus);
+
+  useEffect(() => {
+    if (!deliveryStatusResponse) return;
+
+    showNotification("Delivery status updated successfully", "success");
+    setUpdatingOrderId(null);
+    refetch({ market_id });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [deliveryStatusResponse]);
+
+  useEffect(() => {
+    if (!deliveryStatusError) return;
+
+    showNotification(
+      deliveryStatusError.message || "Unable to update delivery status",
+      "error"
+    );
+    setUpdatingOrderId(null);
+  }, [deliveryStatusError]);
+
+  const handleDeliveryStatusChange = (
+    order: IOrders,
+    status: IOrders["delivery_status"]
+  ) => {
+    const orderId = order.order_id ?? order.id;
+    if (!orderId || !status) {
+      showNotification("Unable to update delivery status: missing order id", "error");
+      return;
+    }
+
+    setUpdatingOrderId(String(orderId));
+    updateDeliveryStatus({ id: orderId, status });
+  };
 
   const handleReconcilePendingPayments = async () => {
     setIsReconciling(true);
@@ -89,8 +138,38 @@ export function MarketOrders() {
           return <span>{formatOrderDateTime(timestamp)}</span>;
         },
       },
+      {
+        header: "Update Delivery",
+        cell: ({ row }) => {
+          const order = row.original;
+          const orderId = String(order.order_id ?? order.id ?? "");
+          const isThisRowUpdating =
+            isUpdatingDeliveryStatus && updatingOrderId === orderId;
+
+          return (
+            <select
+              className="border rounded px-2 py-1 text-xs capitalize disabled:opacity-50"
+              value={order.delivery_status || "pending"}
+              disabled={isThisRowUpdating}
+              onChange={(event) =>
+                handleDeliveryStatusChange(
+                  order,
+                  event.target.value as IOrders["delivery_status"]
+                )
+              }
+            >
+              {DELIVERY_STATUS_OPTIONS.map((status) => (
+                <option key={status} value={status} className="capitalize">
+                  {status}
+                </option>
+              ))}
+            </select>
+          );
+        },
+      },
     ]);
-  }, []);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isUpdatingDeliveryStatus, updatingOrderId]);
 
   return (
     <div className="mb-10">

--- a/src/pages/HomePage/pages/MarketPlace/components/Orders/Orders.tsx
+++ b/src/pages/HomePage/pages/MarketPlace/components/Orders/Orders.tsx
@@ -7,6 +7,7 @@ import { HeaderControls } from "@/components/HeaderControls";
 import TableComponent from "@/pages/HomePage/Components/reusable/TableComponent";
 import type { IOrders, PaymentStatus } from "@/utils";
 import { OrderFilters } from "./OrderFilters";
+import { getDeliveryStatusBadge } from "./OrdersTableColumns";
 
 const getStatusBadge = (status: PaymentStatus) => {
   const base =
@@ -85,7 +86,10 @@ const OrderCard = ({
         <p className="text-sm font-medium">
           GHC {total} • Qty {order.quantity}
         </p>
-        {getStatusBadge(order.payment_status)}
+        <div className="flex items-center gap-2">
+          {getStatusBadge(order.payment_status)}
+          {getDeliveryStatusBadge(order.delivery_status)}
+        </div>
       </div>
 
       {/* Attributes */}

--- a/src/pages/HomePage/pages/MarketPlace/components/Orders/OrdersTableColumns.tsx
+++ b/src/pages/HomePage/pages/MarketPlace/components/Orders/OrdersTableColumns.tsx
@@ -62,6 +62,11 @@ export const getBaseOrderColumns = (
     accessorKey: "payment_status",
     cell: ({ row }) => getStatusBadge(row.original.payment_status),
   },
+  {
+    header: "Delivery",
+    accessorKey: "delivery_status",
+    cell: ({ row }) => getDeliveryStatusBadge(row.original.delivery_status),
+  },
 ];
 
 export const getStatusColor = (status: string) => {
@@ -82,6 +87,30 @@ export const getStatusBadge = (status: string) => {
   return (
     <span className={`inline-block px-2 py-1 rounded ${color}`}>
       {status?.charAt(0).toUpperCase() + status?.slice(1)}
+    </span>
+  );
+};
+
+export const getDeliveryStatusColor = (status?: string) => {
+  switch (status) {
+    case "shipped":
+      return "bg-blue-100 text-blue-700";
+    case "delivered":
+      return "bg-green-100 text-green-700";
+    case "cancelled":
+      return "bg-red-100 text-red-700";
+    case "pending":
+    default:
+      return "bg-[#EAECF0] text-gray-700";
+  }
+};
+
+export const getDeliveryStatusBadge = (status?: string) => {
+  const label = status || "pending";
+  const color = getDeliveryStatusColor(status);
+  return (
+    <span className={`inline-block px-2 py-1 rounded capitalize ${color}`}>
+      {label}
     </span>
   );
 };

--- a/src/utils/api/apiPut.ts
+++ b/src/utils/api/apiPut.ts
@@ -26,7 +26,12 @@ import {
   VisitPayloadType,
 } from "./visitors/interfaces";
 import { EventType } from "./events/interfaces";
-import type { IMarket, IProductType, IProduct } from "./marketPlace/interface";
+import type {
+  IMarket,
+  IProductType,
+  IProduct,
+  IOrders,
+} from "./marketPlace/interface";
 import type {
   Appointment,
   StaffAvailability,
@@ -468,6 +473,15 @@ export class ApiUpdateCalls {
     return this.apiExecution.updateData("appointment/status", payload, {
       id: appointmentId,
     });
+  };
+
+  updateOrderDeliveryStatus = (
+    payload: {
+      id: number | string;
+      status: "pending" | "shipped" | "delivered" | "cancelled";
+    }
+  ): Promise<ApiResponse<IOrders>> => {
+    return this.apiExecution.updateData("orders/update-delivery-status", payload);
   };
 
   // uodate church attendance

--- a/src/utils/api/marketPlace/interface.ts
+++ b/src/utils/api/marketPlace/interface.ts
@@ -133,7 +133,7 @@ export interface RetryOrderPaymentPayload {
 export type PaymentStatus = "pending" | "success" | "failed" | "delivered";
 export interface IOrders extends ICartItem, IUserDetails {
   payment_status: PaymentStatus;
-  delivery_status?: "pending" | "delivered" | "cancelled";
+  delivery_status?: "pending" | "shipped" | "delivered" | "cancelled";
   market_status: MarketStatusType;
   order_number: string;
   order_id?: string | number;


### PR DESCRIPTION
Add delivery-status support and an in-UI update flow for marketplace orders. Changes: extend IOrders.delivery_status to include "shipped"; add ApiUpdateCalls.updateOrderDeliveryStatus endpoint; render a Delivery column and delivery badges (color styles) in orders table; show delivery badge on order cards; add a select control in MarketOrders to change status using usePut with per-row loading, notifications, and refetch after success. Enables admins to update order delivery state (pending, shipped, delivered, cancelled) from the marketplace UI.

## Description
Describe the purpose of this pull request.

## Checklist
- [ ] Tests have been added to all functions
- [ ] Documentation has been updated
- [ ] Changes follow coding standards
