### PR TITLE
Add dark mode support and standardize design tokens

### DIFF
--- a/src/pages/HomePage/pages/MarketPlace/components/Orders/OrderStatusTimeline.tsx
+++ b/src/pages/HomePage/pages/MarketPlace/components/Orders/OrderStatusTimeline.tsx
@@ -36,7 +36,7 @@ export function OrderStatusTimeline({ paymentStatus, deliveryStatus }: IProps) {
 
   if (isFailed) {
     return (
-      <p className="text-sm font-medium text-red-600">
+      <p className="text-sm font-medium text-red-600 dark:text-red-400">
         Payment failed — this order was not completed.
       </p>
     );
@@ -44,52 +44,54 @@ export function OrderStatusTimeline({ paymentStatus, deliveryStatus }: IProps) {
 
   return (
     <div className="space-y-2">
-      <div className="flex items-center">
-        {STEPS.map((step, index) => {
-          const isComplete = index <= completedSteps;
-          const isCurrent = index === completedSteps + 1 && !isCancelled;
-          const isLast = index === STEPS.length - 1;
+      <div className="overflow-x-auto">
+        <div className="flex items-center min-w-max">
+          {STEPS.map((step, index) => {
+            const isComplete = index <= completedSteps;
+            const isCurrent = index === completedSteps + 1 && !isCancelled;
+            const isLast = index === STEPS.length - 1;
 
-          return (
-            <div key={step} className="flex flex-1 items-center last:flex-none">
-              <div className="flex flex-col items-center gap-1">
-                <div
-                  className={cn(
-                    "flex h-6 w-6 items-center justify-center rounded-full border-2 text-xs font-semibold",
-                    isComplete
-                      ? "border-primary bg-primary text-white"
-                      : isCurrent
-                      ? "border-primary text-primary"
-                      : "border-lightGray text-primaryGray"
-                  )}
-                >
-                  {isComplete ? <CheckCircleIcon className="h-4 w-4" /> : index + 1}
+            return (
+              <div key={step} className="flex flex-1 items-center last:flex-none">
+                <div className="flex flex-col items-center gap-1">
+                  <div
+                    className={cn(
+                      "flex h-6 w-6 items-center justify-center rounded-full border-2 text-xs font-semibold",
+                      isComplete
+                        ? "border-primary bg-primary text-white"
+                        : isCurrent
+                        ? "border-primary text-primary"
+                        : "border-lightGray text-primaryGray"
+                    )}
+                  >
+                    {isComplete ? <CheckCircleIcon className="h-4 w-4" /> : index + 1}
+                  </div>
+                  <span
+                    className={cn(
+                      "whitespace-nowrap text-[11px]",
+                      isComplete || isCurrent
+                        ? "font-medium text-primary"
+                        : "text-primaryGray"
+                    )}
+                  >
+                    {step}
+                  </span>
                 </div>
-                <span
-                  className={cn(
-                    "whitespace-nowrap text-[11px]",
-                    isComplete || isCurrent
-                      ? "font-medium text-primary"
-                      : "text-primaryGray"
-                  )}
-                >
-                  {step}
-                </span>
+                {!isLast && (
+                  <div
+                    className={cn(
+                      "mx-1 h-0.5 flex-1",
+                      index < completedSteps ? "bg-primary" : "bg-lightGray"
+                    )}
+                  />
+                )}
               </div>
-              {!isLast && (
-                <div
-                  className={cn(
-                    "mx-1 h-0.5 flex-1",
-                    index < completedSteps ? "bg-primary" : "bg-lightGray"
-                  )}
-                />
-              )}
-            </div>
-          );
-        })}
+            );
+          })}
+        </div>
       </div>
       {isCancelled && (
-        <p className="text-sm font-medium text-red-600">
+        <p className="text-sm font-medium text-red-600 dark:text-red-400">
           This order was cancelled after payment.
         </p>
       )}

--- a/src/pages/HomePage/pages/MarketPlace/components/Orders/Orders.tsx
+++ b/src/pages/HomePage/pages/MarketPlace/components/Orders/Orders.tsx
@@ -17,19 +17,19 @@ const getStatusBadge = (status: PaymentStatus) => {
     case "success":
     case "delivered":
       return (
-        <span className={`${base} bg-green-100 text-green-700`}>
+        <span className={`${base} bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300`}>
           {status}
         </span>
       );
     case "pending":
       return (
-        <span className={`${base} bg-yellow-100 text-yellow-700`}>
+        <span className={`${base} bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-300`}>
           {status}
         </span>
       );
     default:
       return (
-        <span className={`${base} bg-red-100 text-red-700`}>
+        <span className={`${base} bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300`}>
           {status}
         </span>
       );

--- a/src/pages/HomePage/pages/MarketPlace/components/Orders/OrdersTableColumns.tsx
+++ b/src/pages/HomePage/pages/MarketPlace/components/Orders/OrdersTableColumns.tsx
@@ -72,7 +72,7 @@ export const getBaseOrderColumns = (
 export const getStatusColor = (status: string) => {
   switch (status) {
     case "pending":
-      return "bg-[#EAECF0]";
+      return "bg-lightGray/40";
     case "success":
     case "delivered":
       return "bg-green-500 text-white";
@@ -94,14 +94,14 @@ export const getStatusBadge = (status: string) => {
 export const getDeliveryStatusColor = (status?: string) => {
   switch (status) {
     case "shipped":
-      return "bg-blue-100 text-blue-700";
+      return "bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300";
     case "delivered":
-      return "bg-green-100 text-green-700";
+      return "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300";
     case "cancelled":
-      return "bg-red-100 text-red-700";
+      return "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300";
     case "pending":
     default:
-      return "bg-[#EAECF0] text-gray-700";
+      return "bg-lightGray/40 text-gray-700";
   }
 };
 

--- a/src/pages/HomePage/pages/MarketPlace/components/ProductDetails.tsx
+++ b/src/pages/HomePage/pages/MarketPlace/components/ProductDetails.tsx
@@ -244,7 +244,7 @@ export function ProductDetails({ product, addToCart, relatedProducts = [] }: IPr
           <div className="text-xl font-bold ">Product Specification</div>
         </div>
       )}
-      <div className=" mx-auto max-w-6xl  rounded-lg   p-4 grid grid-cols-1 lg:grid-cols-2 gap-10 text-[#404040]">
+      <div className=" mx-auto max-w-6xl  rounded-lg   p-4 grid grid-cols-1 lg:grid-cols-2 gap-10 text-primary">
         {/* Image Section */}
         <div className="">
           <div className=" border p-2 rounded-lg overflow-hidden ">
@@ -309,7 +309,7 @@ export function ProductDetails({ product, addToCart, relatedProducts = [] }: IPr
           <div className="space-y-2">
             <h1 className="text-2xl font-bold">{product.name}</h1>
             {productOutOfStock && (
-              <span className="inline-block bg-red-100 text-red-700 text-xs font-semibold px-2 py-1 rounded">
+              <span className="inline-block bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300 text-xs font-semibold px-2 py-1 rounded">
                 Out of stock
               </span>
             )}
@@ -388,9 +388,9 @@ export function ProductDetails({ product, addToCart, relatedProducts = [] }: IPr
           {is_not_admin && (
             <div className="flex flex-col gap-2 w-full">
               {productOutOfStock ? (
-                <p className="text-red-600 font-semibold">Out of stock</p>
+                <p className="text-red-600 dark:text-red-400 font-semibold">Out of stock</p>
               ) : selectionOutOfStock ? (
-                <p className="text-red-600 text-sm">This colour/size is out of stock.</p>
+                <p className="text-red-600 dark:text-red-400 text-sm">This colour/size is out of stock.</p>
               ) : null}
               <div className="flex gap-4 flex-wrap w-full">
                 <Button
@@ -422,7 +422,7 @@ export function ProductDetails({ product, addToCart, relatedProducts = [] }: IPr
 
       {relatedProducts.length > 0 && (
         <div className="mx-auto max-w-6xl px-4 pb-10">
-          <h3 className="text-lg font-bold text-[#404040] mb-4">You may also like</h3>
+          <h3 className="text-lg font-bold text-primary mb-4">You may also like</h3>
           <div className="grid grid-cols-2 sm:grid-cols-2 lg:grid-cols-4 gap-4">
             {relatedProducts.map((related) => (
               <ProductCard
@@ -448,7 +448,7 @@ export function ProductDetails({ product, addToCart, relatedProducts = [] }: IPr
         className="max-w-xl"
       >
         <div className="p-6 space-y-4">
-          <h3 className="text-lg font-bold text-[#404040]">
+          <h3 className="text-lg font-bold text-primary">
             Confirm {pendingPurchase?.action === "buy_now" ? "Purchase" : "Cart Item"}
           </h3>
 
@@ -463,7 +463,7 @@ export function ProductDetails({ product, addToCart, relatedProducts = [] }: IPr
               </div>
 
               <div className="space-y-1 text-sm text-gray-700">
-                <p className="font-semibold text-base text-[#404040]">
+                <p className="font-semibold text-base text-primary">
                   {pendingPurchase.item.name}
                 </p>
                 <p>
@@ -580,7 +580,7 @@ const QuantityButton = ({
   return (
     <button
       className={cn(
-        " h-full hover:bg-gray-100 bg-[#F3F4F6] w-8 flex items-center justify-center disabled:cursor-not-allowed",
+        " h-full hover:bg-gray-100 bg-inputBackground w-8 flex items-center justify-center disabled:cursor-not-allowed",
         className
       )}
       onClick={onClick}

--- a/src/pages/HomePage/pages/MarketPlace/components/cards/MarketCard.tsx
+++ b/src/pages/HomePage/pages/MarketPlace/components/cards/MarketCard.tsx
@@ -26,7 +26,7 @@ export function MarketCard({
   const [showOptions, setShowOptions] = useState(false);
 
   return (
-    <div className="w-full flex flex-col justify-between rounded-2xl text-[#474D66] border border-lightGray p-4 bg-white shadow-sm transition-shadow hover:shadow-md relative">
+    <div className="w-full flex flex-col justify-between rounded-2xl text-primaryGray border border-lightGray p-4 bg-white shadow-sm transition-shadow hover:shadow-md relative">
       <div>
         <div className="flex justify-between items-start gap-2">
           <div>
@@ -54,7 +54,7 @@ export function MarketCard({
 
         <p className="my-3">{description}</p>
 
-        <div className="flex items-center gap-2 text-[#101840]">
+        <div className="flex items-center gap-2 text-primary">
           <CalendarIcon className="h-5 w-5 text-black" />
           <span>
             {formatDate(start_date)} to {formatDate(end_date)}

--- a/src/pages/HomePage/pages/MarketPlace/components/cards/ProductCard.tsx
+++ b/src/pages/HomePage/pages/MarketPlace/components/cards/ProductCard.tsx
@@ -29,7 +29,7 @@ export const ProductCard = ({ product, handleViewProduct }: IProps) => {
       onClick={() => handleViewProduct(`${product.id}`)}
       className="group w-full rounded-xl bg-white text-left shadow-sm transition-shadow duration-300 hover:shadow-md"
     >
-      <div className="relative overflow-hidden rounded-t-xl bg-[#F5F5F5]">
+      <div className="relative overflow-hidden rounded-t-xl bg-inputBackground">
         <img
           src={`${product?.product_colours?.[0]?.image_url}`}
           alt={`${product.name} product image`}
@@ -48,10 +48,10 @@ export const ProductCard = ({ product, handleViewProduct }: IProps) => {
             {product.product_category.name}
           </p>
         )}
-        <h2 className="line-clamp-1 text-sm font-semibold text-[#404040]">
+        <h2 className="line-clamp-1 text-sm font-semibold text-primary">
           {product.name}
         </h2>
-        <p className="text-base font-bold text-[#404040]">
+        <p className="text-base font-bold text-primary">
           {product.price_currency || "GHC"} {Number(product.price_amount).toFixed(2)}
         </p>
         {visibleSwatches.length > 0 && (

--- a/src/pages/HomePage/pages/MarketPlace/components/cart/CartDrawer.tsx
+++ b/src/pages/HomePage/pages/MarketPlace/components/cart/CartDrawer.tsx
@@ -46,7 +46,7 @@ export default function CartDrawer() {
       }`}
       ref={drawerRef}
     >
-      <div className="flex items-center justify-between border-b border-lightGray px-5 py-4">
+      <div className="flex items-center justify-between border-b border-lightGray px-4 py-4 sm:px-5">
         <div className="flex items-center gap-2">
           <ShoppingCartIcon className="size-6" />
           <h2 className="text-lg font-bold">Your cart</h2>
@@ -60,7 +60,7 @@ export default function CartDrawer() {
         </button>
       </div>
 
-      <div className="max-h-[60vh] divide-y divide-lightGray overflow-y-auto px-5">
+      <div className="max-h-[60vh] divide-y divide-lightGray overflow-y-auto px-4 sm:px-5">
         {cartWithDetails.length === 0 ? (
           <div className="py-6">
             <EmptyCartComponent />
@@ -77,7 +77,7 @@ export default function CartDrawer() {
       </div>
 
       {cartWithDetails.length > 0 && (
-        <div className="space-y-3 border-t border-lightGray px-5 py-4">
+        <div className="space-y-3 border-t border-lightGray px-4 py-4 sm:px-5">
           <div className="flex items-center justify-between">
             <p className="text-sm font-medium text-primaryGray">Subtotal</p>
             <p className="text-lg font-bold">GHC {totalPrice.toFixed(2)}</p>
@@ -131,7 +131,7 @@ const CartCard = ({ cartItem, onDelete }: CartCardProps) => {
       </div>
       <button
         onClick={() => onDelete(cartItem.item_uuid!)}
-        className="rounded-full p-1 text-primaryGray hover:bg-lightGray/40 hover:text-red-600"
+        className="rounded-full p-1 text-primaryGray hover:bg-lightGray/40 hover:text-red-600 dark:hover:text-red-400"
         aria-label={`Remove ${cartItem.name} from cart`}
       >
         <XMarkIcon className="size-4" />

--- a/src/pages/HomePage/pages/MarketPlace/components/cart/CheckOutForm.tsx
+++ b/src/pages/HomePage/pages/MarketPlace/components/cart/CheckOutForm.tsx
@@ -102,7 +102,7 @@ export function CheckoutForm(props: IProps) {
   };
 
   return (
-    <div className="text-[#474D66] bg-white rounded-lg ">
+    <div className="text-primaryGray bg-white rounded-lg ">
       <Formik
         initialValues={initialValues}
         validationSchema={validationSchema}
@@ -155,7 +155,7 @@ export function CheckoutForm(props: IProps) {
         onClose={closeOrderConfirmation}
         className="max-w-2xl"
       >
-        <div className="p-6 space-y-5 text-[#474D66]">
+        <div className="p-6 space-y-5 text-primaryGray">
           <h3 className="text-xl font-bold">Confirm Order</h3>
 
           <div className="max-h-[45vh] overflow-y-auto space-y-3">
@@ -217,7 +217,7 @@ export function CheckoutForm(props: IProps) {
             </p>
           </div>
 
-          <div className="rounded-lg border border-amber-300 bg-amber-50 p-4 space-y-3">
+          <div className="rounded-lg border border-amber-300 bg-amber-50 p-4 space-y-3 dark:border-amber-800 dark:bg-amber-900/30">
             <p className="font-bold">⚠️ Please Review Your Order Carefully</p>
             <label
               htmlFor="order-acknowledgement"
@@ -385,7 +385,7 @@ const ItemCard = ({ item, editable, onQuantityChange, onRemove }: ICardProp) => 
             type="button"
             aria-label={`Remove ${item.name}`}
             onClick={() => onRemove?.(item)}
-            className="text-gray-400 hover:text-red-600"
+            className="p-1 text-gray-400 hover:text-red-600 dark:hover:text-red-400"
           >
             <XMarkIcon className="size-4" />
           </button>

--- a/src/pages/HomePage/pages/MarketPlace/components/chips/ProductChip.tsx
+++ b/src/pages/HomePage/pages/MarketPlace/components/chips/ProductChip.tsx
@@ -9,8 +9,8 @@ export function ProductChip({
     section === "category"
       ? "bg-primary text-white"
       : section === "type"
-      ? "bg-[#EAECF0] text-[#474D66]"
-      : "bg-[#F9F9F9] border border-[#EAECF0]";
+      ? "bg-lightGray/40 text-primaryGray"
+      : "bg-inputBackground border border-borderGray";
 
   return (
     <div className={`${pillStyles} rounded-lg px-2 py-1 w-fit h-fit text-xs`}>{text}</div>

--- a/src/pages/MembersPage/Component/AppointmentBookingForm.tsx
+++ b/src/pages/MembersPage/Component/AppointmentBookingForm.tsx
@@ -851,16 +851,16 @@ const AppointmentBookingForm = ({
               />
 
               {availabilityLoading && (
-                <div className="text-sm text-muted-foreground">
+                <div className="text-sm text-primaryGray">
                   Loading staff availability...
                 </div>
               )}
 
               {selectedStaff && (
-                <div className="text-sm bg-muted p-3 rounded break-words">
+                <div className="text-sm bg-lightGray/40 p-3 rounded break-words">
                   <strong>Availability</strong>
                   {selectedStaff.timeSlots.length === 0 && (
-                    <p className="mt-1 text-muted-foreground">
+                    <p className="mt-1 text-primaryGray">
                       No configured availability for this staff member.
                     </p>
                   )}
@@ -917,7 +917,7 @@ const AppointmentBookingForm = ({
                 </p>
               )}
               {!isSelectedDateAllowed && (
-                <p className="text-sm text-red-600">
+                <p className="text-sm text-red-600 dark:text-red-400">
                   Please choose one of the available days for this staff member.
                 </p>
               )}
@@ -987,7 +987,7 @@ const AppointmentBookingForm = ({
                   </div>
 
                   {sessionTouched && typeof sessionError === "string" && (
-                    <p className="text-sm text-red-600">{sessionError}</p>
+                    <p className="text-sm text-red-600 dark:text-red-400">{sessionError}</p>
                   )}
                 </div>
               )}
@@ -997,7 +997,7 @@ const AppointmentBookingForm = ({
                 !availabilityLoading &&
                 isSelectedDateAllowed &&
                 slotsForDay.length === 0 && (
-                  <div className="text-sm text-muted-foreground">
+                  <div className="text-sm text-primaryGray">
                     No available time slots for the selected date.
                   </div>
                 )}

--- a/src/pages/MembersPage/Component/AppointmentCard.tsx
+++ b/src/pages/MembersPage/Component/AppointmentCard.tsx
@@ -24,15 +24,15 @@ interface AppointmentCardProps {
 const getStatusColor = (status?: string) => {
   switch ((status || "").toLowerCase()) {
     case "confirmed":
-      return "bg-emerald-100 text-sm text-emerald-700 border border-emerald-200";
+      return "bg-emerald-100 text-sm text-emerald-700 border border-emerald-200 dark:bg-emerald-900/30 dark:text-emerald-300 dark:border-emerald-800";
     case "cancelled":
-      return "bg-red-100 text-sm text-red-700 border border-red-200";
+      return "bg-red-100 text-sm text-red-700 border border-red-200 dark:bg-red-900/30 dark:text-red-300 dark:border-red-800";
     case "pending":
-      return "bg-amber-100 text-sm text-amber-700 border border-amber-200";
+      return "bg-amber-100 text-sm text-amber-700 border border-amber-200 dark:bg-amber-900/30 dark:text-amber-300 dark:border-amber-800";
     case "completed":
-      return "bg-blue-100 text-sm text-blue-700 border border-blue-200";
+      return "bg-blue-100 text-sm text-blue-700 border border-blue-200 dark:bg-blue-900/30 dark:text-blue-300 dark:border-blue-800";
     case "rescheduled":
-      return "bg-indigo-100 text-sm text-indigo-700 border border-indigo-200";
+      return "bg-indigo-100 text-sm text-indigo-700 border border-indigo-200 dark:bg-indigo-900/30 dark:text-indigo-300 dark:border-indigo-800";
     default:
       return "bg-gray-100 text-sm text-gray-600 border border-gray-300";
   }
@@ -130,10 +130,10 @@ const AppointmentCard = ({
                 if (deleteDisabled) return;
                 onDelete(appointment);
               }}
-              className={`inline-flex h-9 w-9 items-center justify-center rounded-lg border border-red-200 bg-white text-red-600 ${
+              className={`inline-flex h-9 w-9 items-center justify-center rounded-lg border border-red-200 bg-white text-red-600 dark:border-red-800 dark:text-red-400 ${
                 deleteDisabled
                   ? "cursor-not-allowed opacity-50"
-                  : "hover:bg-red-50"
+                  : "hover:bg-red-50 dark:hover:bg-red-900/30"
               }`}
               aria-label="Delete appointment"
             >

--- a/src/pages/MembersPage/Component/AssMatSidebar.tsx
+++ b/src/pages/MembersPage/Component/AssMatSidebar.tsx
@@ -9,7 +9,7 @@ const AssMatSidebar = ({materials, assignments}: {materials: any[], assignments:
     <aside className="w-full space-y-6  lg:flex-shrink-0">
       {/* Assignments */}
       <div>
-        <h3 className="mb-4 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+        <h3 className="mb-4 text-xs font-semibold uppercase tracking-wider text-primaryGray">
           Assignment
         </h3>
         <div className="space-y-3">
@@ -27,7 +27,7 @@ const AssMatSidebar = ({materials, assignments}: {materials: any[], assignments:
 
       {/* Materials */}
       <div>
-        <h3 className="mb-4 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+        <h3 className="mb-4 text-xs font-semibold uppercase tracking-wider text-primaryGray">
           Material
         </h3>
         <div className="space-y-2">

--- a/src/pages/MembersPage/Component/AssignmentCard.tsx
+++ b/src/pages/MembersPage/Component/AssignmentCard.tsx
@@ -11,17 +11,17 @@ interface AssignmentCardProps {
 
 const AssignmentCard = ({ name, dueDate, submittedDate, status }: AssignmentCardProps) => {
   return (
-    <div className="rounded-lg border border-border bg-white p-4 transition-shadow hover:shadow-sm">
+    <div className="rounded-lg border border-lightGray bg-white p-4 transition-shadow hover:shadow-sm">
       <div className="flex items-start justify-between">
-        <h4 className="text-sm font-medium text-foreground">{name}</h4>
+        <h4 className="text-sm font-medium text-primary">{name}</h4>
         {status === "submitted" && (
-          <span className="rounded-full bg-success/10 px-2.5 py-0.5 text-xs font-medium text-success">
+          <span className="rounded-full bg-success/10 px-2.5 py-0.5 text-xs font-medium text-success dark:bg-green-900/30 dark:text-green-300">
             submitted
           </span>
         )}
       </div>
 
-      <div className="mt-3 flex gap-6 text-xs text-muted-foreground">
+      <div className="mt-3 flex gap-6 text-xs text-primaryGray">
         <div>
           <span className="block font-medium">Due</span>
           <span>{formatDatefull(dueDate)}</span>

--- a/src/pages/MembersPage/Component/AssignmentManager.tsx
+++ b/src/pages/MembersPage/Component/AssignmentManager.tsx
@@ -90,27 +90,27 @@ const AssignmentManager = ({ cohortId, assignments, setSelectedAssignment: _setS
     return ( 
         <div className="flex flex-col gap-4 lg:flex-1">
                               {assignments.length === 0 ? (
-                                <div className="rounded-xl border border-border p-6 bg-card text-muted-foreground">No assignments match the selected filters.</div>
+                                <div className="rounded-xl border border-lightGray p-6 bg-white text-primaryGray">No assignments match the selected filters.</div>
                               ) : (
                                 assignments.map((topic) => (
                                   <div
                                     key={topic.id}
-                                    className="flex items-center gap-6 border border-border rounded-xl justify-between p-4 w-full bg-card"
+                                    className="flex items-center gap-6 border border-lightGray rounded-xl justify-between p-4 w-full bg-white"
                                   >
                                     <div>
                                       <div className="flex items-center gap-3">
-                                        <h3 className="font-medium text-lg text-foreground">{topic.title}</h3>
+                                        <h3 className="font-medium text-lg text-primary">{topic.title}</h3>
                                         <Badge
                                           className={`text-xs border normal-case text-white ${
                                             topic.isActive
-                                              ? "border-green-500 bg-green-400"
+                                              ? "border-green-500 bg-green-400 dark:border-green-400"
                                               : "border-gray-400 bg-gray-400"
                                           }`}
                                         >
                                           {topic.isActive ? "Active" : "Inactive"}
                                         </Badge>
                                       </div>
-                                      <div className="flex gap-4 text-sm text-muted-foreground">
+                                      <div className="flex gap-4 text-sm text-primaryGray">
                                         <div>
                                           Due: {topic?.dueDate ? formatDatefull(topic.dueDate) : "N/A"}
                                         </div>
@@ -159,7 +159,7 @@ const AssignmentManager = ({ cohortId, assignments, setSelectedAssignment: _setS
                                     <div className="flex items-start justify-between">
                                       <div>
                                         <h2 className="text-xl font-semibold text-gray-900">Activate Assignment</h2>
-                                        <p className="text-sm text-muted-foreground mt-1">
+                                        <p className="text-sm text-primaryGray mt-1">
                                           Set a due date for &quot;{selectedAssignment.title}&quot;
                                         </p>
                                       </div>
@@ -209,7 +209,7 @@ const AssignmentManager = ({ cohortId, assignments, setSelectedAssignment: _setS
                                       <h2 className="text-xl font-semibold text-gray-900">
                                         Deactivate Assignment
                                       </h2>
-                                      <p className="text-sm text-muted-foreground mt-1">
+                                      <p className="text-sm text-primaryGray mt-1">
                                         Are you sure you want to deactivate &quot;{selectedAssignment.title}&quot;?
                                       </p>
                                     </div>

--- a/src/pages/MembersPage/Component/CourseSidebar.tsx
+++ b/src/pages/MembersPage/Component/CourseSidebar.tsx
@@ -29,7 +29,7 @@ const CourseSidebar: React.FC<CourseSidebarProps> = ({
   const renderIcon = (nav: NavItem) => {
     const iconClass = cn(
       "h-6 w-6",
-      nav.active ? "text-white" : nav.completed?"text-lime-700":"text-primary"
+      nav.active ? "text-white" : nav.completed?"text-lime-700 dark:text-lime-400":"text-primary"
     );
 
     if (nav.completed) {
@@ -61,8 +61,8 @@ const CourseSidebar: React.FC<CourseSidebarProps> = ({
 
   return (
     <aside className="w-full  lg:flex-shrink-0 " aria-label={`${heading} sidebar`}>
-      <div className="rounded-xl border border-border bg-white p-4">
-        <h2 className="mb-4 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+      <div className="rounded-xl border border-lightGray bg-white p-4">
+        <h2 className="mb-4 text-xs font-semibold uppercase tracking-wider text-primaryGray">
           {heading}
         </h2>
 
@@ -77,7 +77,7 @@ const CourseSidebar: React.FC<CourseSidebarProps> = ({
                 "flex w-full items-center justify-between rounded-lg px-3 py-2.5 text-left text-sm font-medium transition-all",
                 nav.active
                   ? "bg-primary text-white"
-                  : "text-muted-foreground hover:bg-primary/15 hover:text-foreground"
+                  : "text-primaryGray hover:bg-primary/15 hover:text-primary"
               )}
               style={{ animationDelay: `${index * 50}ms` }}
             >

--- a/src/pages/MembersPage/Component/MaterialItem.tsx
+++ b/src/pages/MembersPage/Component/MaterialItem.tsx
@@ -8,17 +8,17 @@ interface MaterialItemProps {
 
 const MaterialItem = ({ name, size }: MaterialItemProps) => {
   return (
-    <div className="flex items-center justify-between rounded-lg border border-border bg-white px-4 py-3 transition-colors hover:bg-primary/15">
-      <div className="flex items-center gap-3">
-        <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-gray-200">
-          <DocumentTextIcon className="h-4 w-4 text-muted-foreground" />
+    <div className="flex items-center justify-between rounded-lg border border-lightGray bg-white px-4 py-3 transition-colors hover:bg-primary/15">
+      <div className="flex min-w-0 items-center gap-3">
+        <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-gray-200">
+          <DocumentTextIcon className="h-4 w-4 text-primaryGray" />
         </div>
-        <div>
-          <p className="text-sm font-medium text-foreground">{name}</p>
-          <p className="text-xs text-muted-foreground">{size}</p>
+        <div className="min-w-0">
+          <p className="truncate text-sm font-medium text-primary">{name}</p>
+          <p className="text-xs text-primaryGray">{size}</p>
         </div>
       </div>
-      <button className="rounded-lg p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground">
+      <button className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg text-primaryGray transition-colors hover:bg-lightGray/40 hover:text-primary">
         <ArrowDownTrayIcon className="h-4 w-4" />
       </button>
     </div>

--- a/src/pages/MembersPage/Component/ProgramDetailsModal.tsx
+++ b/src/pages/MembersPage/Component/ProgramDetailsModal.tsx
@@ -30,7 +30,7 @@ const Badge: FC<{ variant?: "default" | "full"; children: ReactNode }> = ({
   <span
     className={`inline-flex items-center rounded-full px-2.5 py-1 text-xs font-semibold ${
       variant === "full"
-        ? "bg-red-50 text-red-700"
+        ? "bg-red-50 text-red-700 dark:bg-red-900/30 dark:text-red-300"
         : "bg-lightGray/50 text-primaryGray"
     }`}
   >
@@ -41,7 +41,7 @@ const Badge: FC<{ variant?: "default" | "full"; children: ReactNode }> = ({
 const ProgressBar: FC<{ value: number; isFull?: boolean }> = ({ value, isFull }) => (
   <div className="h-1 w-full overflow-hidden rounded-full bg-lightGray/50">
     <div 
-      className={`h-full transition-all duration-300 ${isFull ? "bg-red-500" : "bg-primary"}`}
+      className={`h-full transition-all duration-300 ${isFull ? "bg-red-500 dark:bg-red-400" : "bg-primary"}`}
       style={{ width: `${value}%` }} 
     />
   </div>

--- a/src/pages/MembersPage/Pages/GivingComplete.tsx
+++ b/src/pages/MembersPage/Pages/GivingComplete.tsx
@@ -44,8 +44,8 @@ export default function GivingComplete() {
     <div className="flex items-center justify-center w-full h-[80vh] px-4">
       <div className="bg-white shadow-lg rounded-2xl p-8 w-full max-w-md text-center">
         <div className="flex flex-col items-center gap-4">
-          <CheckCircleIcon className="w-12 h-12 text-green-500" />
-          <p className="text-green-600 font-medium">
+          <CheckCircleIcon className="w-12 h-12 text-green-500 dark:text-green-400" />
+          <p className="text-green-600 font-medium dark:text-green-400">
             Thank you for your giving!
           </p>
 

--- a/src/pages/MembersPage/Pages/GradingPanel.tsx
+++ b/src/pages/MembersPage/Pages/GradingPanel.tsx
@@ -355,11 +355,11 @@ const GradingPanel = () => {
       header: "Status",
       cell: ({ row }) =>
         row.original.status === "pending" ? (
-          <span className="inline-flex rounded-full bg-amber-500/10 px-2 py-0.5 text-xs font-medium text-amber-600">
+          <span className="inline-flex rounded-full bg-amber-500/10 px-2 py-0.5 text-xs font-medium text-amber-600 dark:bg-amber-900/30 dark:text-amber-300">
             Pending
           </span>
         ) : (
-          <span className="inline-flex rounded-full bg-green-500/10 px-2 py-0.5 text-xs font-medium text-green-600">
+          <span className="inline-flex rounded-full bg-green-500/10 px-2 py-0.5 text-xs font-medium text-green-600 dark:bg-green-900/30 dark:text-green-300">
             Graded
           </span>
         ),
@@ -460,7 +460,7 @@ const GradingPanel = () => {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center py-16 text-muted-foreground">
+      <div className="flex items-center justify-center py-16 text-primaryGray">
         Loading assignment results...
       </div>
     );
@@ -468,48 +468,48 @@ const GradingPanel = () => {
 
   if (!assignment) {
     return (
-      <div className="flex flex-col items-center justify-center rounded-xl border border-border bg-card py-16">
-        <p className="mb-4 text-muted-foreground">Select an assignment to grade</p>
+      <div className="flex flex-col items-center justify-center rounded-xl border border-lightGray bg-white py-16">
+        <p className="mb-4 text-primaryGray">Select an assignment to grade</p>
         <Button variant="secondary" value="Back to Assignment" onClick={onBack}/>
       </div>
     );
   }
 
   return (
-    <div className="rounded-xl border border-border w-full">
+    <div className="rounded-xl border border-lightGray w-full">
       {/* Header */}
-      <div className="border-b border-border p-6">
+      <div className="border-b border-lightGray p-6">
         <button
           onClick={onBack}
-          className="mb-3 flex items-center gap-1  text-muted-foreground transition-colors hover:text-foreground"
+          className="mb-3 flex items-center gap-1  text-primaryGray transition-colors hover:text-primary"
         >
           <ArrowLeftIcon className="h-4 w-4" />
           Back to assignments
         </button>
         <div className="flex items-start justify-between">
           <div>
-            <h2 className="text-lg font-semibold text-foreground">{assignment.title}</h2>
-            <div className="mt-2 flex items-center gap-4  text-muted-foreground">
+            <h2 className="text-lg font-semibold text-primary">{assignment.title}</h2>
+            <div className="mt-2 flex items-center gap-4  text-primaryGray">
               <span className="flex items-center gap-1">
                 <UsersIcon className="h-4 w-4" />
                 {totalCount} submissions
               </span>
               <span className="flex items-center gap-1">
-                <ClockIcon className="h-4 w-4 text-amber-600" />
+                <ClockIcon className="h-4 w-4 text-amber-600 dark:text-amber-400" />
                 {pendingCount} pending
               </span>
               <span className="flex items-center gap-1">
-                <CheckIcon className="h-4 w-4 text-green-600" />
+                <CheckIcon className="h-4 w-4 text-green-600 dark:text-green-400" />
                 {gradedCount} graded
               </span>
             </div>
           </div>
           {/* Progress bar */}
           <div className="text-right">
-            <p className=" font-medium text-foreground">
+            <p className=" font-medium text-primary">
               {progress}% complete
             </p>
-            <div className="mt-1 h-2 w-32 overflow-hidden rounded-full bg-muted">
+            <div className="mt-1 h-2 w-32 overflow-hidden rounded-full bg-lightGray/40">
               <div
                 className="h-full bg-primary transition-all"
                 style={{ width: `${progress}%` }}
@@ -519,9 +519,9 @@ const GradingPanel = () => {
         </div>
       </div>
       {/* Controls */}
-      <div className="flex flex-wrap items-center gap-3 border-b border-border p-4">
+      <div className="flex flex-wrap items-center gap-3 border-b border-lightGray p-4">
         <div className="relative flex-1 min-w-[200px]">
-          <SearchIcon className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <SearchIcon className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-primaryGray" />
           <input
             type="text"
             id="search-students"

--- a/src/pages/MembersPage/Pages/InstructorCohort.tsx
+++ b/src/pages/MembersPage/Pages/InstructorCohort.tsx
@@ -107,14 +107,14 @@ const InstructorCohort = () => {
               filteredCohorts.map((cohort) => (
                 <div
                   key={cohort.id}
-                  className="flex w-full items-center justify-between rounded-xl border border-lightGray bg-white p-4"
+                  className="flex w-full flex-col items-start gap-4 rounded-xl border border-lightGray bg-white p-4 sm:flex-row sm:items-center sm:justify-between"
                 >
                   <div className="flex flex-col gap-y-2">
                     <div className="flex items-center gap-x-2">
                       <h3 className="font-medium text-lg">{cohort.name}</h3>
                       <Badge>{cohort.status}</Badge>
                     </div>
-                    <div className="flex gap-4 text-sm text-gray-600">
+                    <div className="flex flex-wrap gap-4 text-sm text-gray-600">
                       <span>Starts: {new Date(cohort.startDate).toLocaleDateString()}</span>
                       <span>•</span>
                       <span>{cohort.duration}</span>

--- a/src/pages/MembersPage/Pages/InstructorProg.tsx
+++ b/src/pages/MembersPage/Pages/InstructorProg.tsx
@@ -123,11 +123,11 @@ const InstructorProg = () => {
               filteredPrograms.map((program) => (
                 <div
                   key={program.id}
-                  className="flex w-full items-center justify-between rounded-xl border border-lightGray bg-white p-4"
+                  className="flex w-full flex-col items-start gap-4 rounded-xl border border-lightGray bg-white p-4 sm:flex-row sm:items-center sm:justify-between"
                 >
                   <div>
                     <h3 className="mb-2 text-lg font-medium text-primary">{program.title}</h3>
-                    <div className="flex gap-4 text-sm text-primaryGray">
+                    <div className="flex flex-wrap gap-4 text-sm text-primaryGray">
                       <span>{program.cohortName}</span>
                       <span>•</span>
                       <span>{program.schedule}</span>

--- a/src/pages/MembersPage/Pages/MemberGiving.tsx
+++ b/src/pages/MembersPage/Pages/MemberGiving.tsx
@@ -34,9 +34,12 @@ const isRetryable = (status: string): boolean =>
   status === "failed" || status === "abandoned";
 
 const statusClass = (status: string): string => {
-  if (status === "success") return "bg-green-100 text-green-700";
-  if (status === "pending") return "bg-amber-100 text-amber-700";
-  if (status === "failed" || status === "abandoned") return "bg-red-100 text-red-700";
+  if (status === "success")
+    return "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300";
+  if (status === "pending")
+    return "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300";
+  if (status === "failed" || status === "abandoned")
+    return "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300";
   return "bg-lightGray text-primaryGray";
 };
 
@@ -329,7 +332,7 @@ const MemberGiving = () => {
                             </button>
                             <button
                               type="button"
-                              className="text-sm font-medium text-red-600 underline disabled:opacity-50"
+                              className="text-sm font-medium text-red-600 underline disabled:opacity-50 dark:text-red-400"
                               disabled={pendingAction === row.reference}
                               onClick={() => remove(row)}
                             >
@@ -426,7 +429,7 @@ const MemberGiving = () => {
               You will be taken to a secure Paystack page, then returned here.
             </p>
 
-            <div className="mt-5 flex justify-end gap-2">
+            <div className="mt-5 flex flex-wrap justify-end gap-2">
               <Button
                 value="Cancel"
                 variant="secondary"

--- a/src/pages/MembersPage/Pages/MemberGivingComplete.tsx
+++ b/src/pages/MembersPage/Pages/MemberGivingComplete.tsx
@@ -62,16 +62,16 @@ const MemberGivingComplete = () => {
       <div className="w-full max-w-md rounded-2xl bg-white p-8 text-center shadow-lg">
         <div className="flex flex-col items-center gap-4">
           {settled ? (
-            <CheckCircleIcon className="h-12 w-12 text-green-500" />
+            <CheckCircleIcon className="h-12 w-12 text-green-500 dark:text-green-400" />
           ) : (
-            <ClockIcon className="h-12 w-12 text-amber-500" />
+            <ClockIcon className="h-12 w-12 text-amber-500 dark:text-amber-400" />
           )}
 
           {loading ? (
             <p className="text-primaryGray">Confirming your payment...</p>
           ) : settled && contribution ? (
             <>
-              <p className="font-medium text-green-600">
+              <p className="font-medium text-green-600 dark:text-green-400">
                 Thank you for your giving!
               </p>
               <p className="text-sm text-primaryGray">

--- a/src/pages/MembersPage/Pages/MemberPledgeComplete.tsx
+++ b/src/pages/MembersPage/Pages/MemberPledgeComplete.tsx
@@ -59,16 +59,16 @@ const MemberPledgeComplete = () => {
       <div className="w-full max-w-md rounded-2xl bg-white p-8 text-center shadow-lg">
         <div className="flex flex-col items-center gap-4">
           {settled ? (
-            <CheckCircleIcon className="h-12 w-12 text-green-500" />
+            <CheckCircleIcon className="h-12 w-12 text-green-500 dark:text-green-400" />
           ) : (
-            <ClockIcon className="h-12 w-12 text-amber-500" />
+            <ClockIcon className="h-12 w-12 text-amber-500 dark:text-amber-400" />
           )}
 
           {loading ? (
             <p className="text-primaryGray">Confirming your payment...</p>
           ) : settled && payment ? (
             <>
-              <p className="font-medium text-green-600">
+              <p className="font-medium text-green-600 dark:text-green-400">
                 Thank you for redeeming your pledge!
               </p>
               <p className="text-sm text-primaryGray">

--- a/src/pages/MembersPage/Pages/MemberPledges.tsx
+++ b/src/pages/MembersPage/Pages/MemberPledges.tsx
@@ -34,9 +34,12 @@ const isRetryable = (status: string): boolean =>
   status === "failed" || status === "abandoned";
 
 const statusClass = (status: string): string => {
-  if (status === "success") return "bg-green-100 text-green-700";
-  if (status === "pending") return "bg-amber-100 text-amber-700";
-  if (status === "failed" || status === "abandoned") return "bg-red-100 text-red-700";
+  if (status === "success")
+    return "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300";
+  if (status === "pending")
+    return "bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300";
+  if (status === "failed" || status === "abandoned")
+    return "bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300";
   return "bg-lightGray text-primaryGray";
 };
 
@@ -278,7 +281,7 @@ const MemberPledges = () => {
                     </p>
                   </div>
 
-                  <div className="grid grid-cols-3 gap-2 text-sm">
+                  <div className="grid grid-cols-1 sm:grid-cols-3 gap-2 text-sm">
                     <div>
                       <div className="text-primaryGray">Pledged</div>
                       <div className="font-semibold">
@@ -314,7 +317,7 @@ const MemberPledges = () => {
                   </div>
 
                   {row.status === "completed" ? (
-                    <p className="text-sm font-medium text-green-700">
+                    <p className="text-sm font-medium text-green-700 dark:text-green-400">
                       Fully redeemed. Thank you.
                     </p>
                   ) : row.can_be_paid_online ? (
@@ -326,7 +329,7 @@ const MemberPledges = () => {
                       }}
                     />
                   ) : (
-                    <p className="text-sm text-amber-700">
+                    <p className="text-sm text-amber-700 dark:text-amber-400">
                       Online payment is not available for this pledge yet.
                       Please contact the church office.
                     </p>
@@ -396,7 +399,7 @@ const MemberPledges = () => {
                             </button>
                             <button
                               type="button"
-                              className="text-sm font-medium text-red-600 underline disabled:opacity-50"
+                              className="text-sm font-medium text-red-600 underline disabled:opacity-50 dark:text-red-400"
                               disabled={pendingAction === row.reference}
                               onClick={() => remove(row)}
                             >
@@ -487,7 +490,7 @@ const MemberPledges = () => {
               You will be taken to a secure Paystack page, then returned here.
             </p>
 
-            <div className="mt-5 flex justify-end gap-2">
+            <div className="mt-5 flex flex-wrap justify-end gap-2">
               <Button
                 value="Cancel"
                 variant="secondary"

--- a/src/pages/MembersPage/Pages/MyAppointments.tsx
+++ b/src/pages/MembersPage/Pages/MyAppointments.tsx
@@ -333,7 +333,7 @@ const MyAppointments = () => {
         </div>
 
         {!requesterId ? (
-          <div className="text-sm text-red-600">
+          <div className="text-sm text-red-600 dark:text-red-400">
             Unable to fetch appointments: requester id is missing.
           </div>
         ) : loading ? (

--- a/src/pages/MembersPage/Pages/MyLearning.tsx
+++ b/src/pages/MembersPage/Pages/MyLearning.tsx
@@ -79,7 +79,7 @@ const MyLearning: React.FC = () => {
               filteredPrograms.map((program: EnrolledProgramResponse) => (
                 <div
                   key={program.id}
-                  className="flex items-center justify-between rounded-xl border border-lightGray bg-white p-4 w-full"
+                  className="flex flex-wrap items-center justify-between gap-4 rounded-xl border border-lightGray bg-white p-4 w-full"
                 >
                   <div>
                     <h3 className="mb-2 text-lg font-medium text-primary">{program.program.title}</h3>

--- a/src/pages/MembersPage/Pages/MyLifeCenter.tsx
+++ b/src/pages/MembersPage/Pages/MyLifeCenter.tsx
@@ -40,7 +40,7 @@ const MyLifeCenter = () => {
               <p>{lifeCenterData?.description || ""}</p>
             )}
           </div>
-          <div className="flex gap-5 items-center ">
+          <div className="flex flex-wrap gap-3 sm:gap-5 items-center ">
             {lifeCenterData?.location && (
               <InfoRow
                 icon={<MapPinIcon className="h-6 w-6 " />}

--- a/src/pages/MembersPage/Pages/MyOrders.tsx
+++ b/src/pages/MembersPage/Pages/MyOrders.tsx
@@ -166,7 +166,7 @@ export const MyOrders = () => {
         className="max-w-lg"
       >
         {viewingOrder && (
-          <div className="space-y-5 p-6 text-[#474D66]">
+          <div className="space-y-5 p-6 text-primary">
             <div>
               <h3 className="text-lg font-bold">{viewingOrder.order_number}</h3>
               <p className="text-sm text-primaryGray">
@@ -180,9 +180,9 @@ export const MyOrders = () => {
             />
 
             <div className="rounded-lg border border-lightGray p-4 space-y-1 text-sm">
-              <p className="flex items-center justify-between">
+              <p className="flex items-center justify-between gap-3">
                 <span className="font-medium">Total</span>
-                <span>
+                <span className="min-w-0 break-words text-right">
                   GHC{" "}
                   {(
                     Number(viewingOrder.price_amount || 0) *
@@ -190,15 +190,15 @@ export const MyOrders = () => {
                   ).toFixed(2)}
                 </span>
               </p>
-              <p className="flex items-center justify-between">
+              <p className="flex items-center justify-between gap-3">
                 <span className="font-medium">Billed to</span>
-                <span>
+                <span className="min-w-0 break-words text-right">
                   {viewingOrder.first_name} {viewingOrder.last_name}
                 </span>
               </p>
-              <p className="flex items-center justify-between">
+              <p className="flex items-center justify-between gap-3">
                 <span className="font-medium">Email</span>
-                <span>{viewingOrder.email}</span>
+                <span className="min-w-0 break-words text-right">{viewingOrder.email}</span>
               </p>
             </div>
 

--- a/src/pages/MembersPage/Pages/PledgeComplete.tsx
+++ b/src/pages/MembersPage/Pages/PledgeComplete.tsx
@@ -44,8 +44,8 @@ export default function PledgeComplete() {
     <div className="flex h-[80vh] w-full items-center justify-center px-4">
       <div className="w-full max-w-md rounded-2xl bg-white p-8 text-center shadow-lg">
         <div className="flex flex-col items-center gap-4">
-          <CheckCircleIcon className="h-12 w-12 text-green-500" />
-          <p className="font-medium text-green-600">
+          <CheckCircleIcon className="h-12 w-12 text-green-500 dark:text-green-400" />
+          <p className="font-medium text-green-600 dark:text-green-400">
             Thank you for redeeming your pledge!
           </p>
 

--- a/src/pages/MembersPage/Pages/ProductsPage.tsx
+++ b/src/pages/MembersPage/Pages/ProductsPage.tsx
@@ -176,7 +176,7 @@ export default function ProductsPage() {
             placeholder="Any"
             value={maxPrice}
             onChange={(e) => setMaxPrice(e.target.value)}
-            className="h-10 w-full rounded-lg border border-[#dcdcdc] bg-white px-3 text-sm text-primary"
+            className="h-10 w-full rounded-lg border border-lightGray bg-white px-3 text-sm text-primary"
           />
         </div>
       </div>

--- a/src/pages/MembersPage/Pages/VerifyPayment.tsx
+++ b/src/pages/MembersPage/Pages/VerifyPayment.tsx
@@ -63,8 +63,8 @@ export default function VerifyPayment() {
       <div className="bg-white shadow-lg rounded-2xl border border-lightGray p-8 w-full max-w-md text-center">
         {!hasReference && (
           <div className="flex flex-col items-center gap-4">
-            <XCircleIcon className="w-12 h-12 text-red-500" />
-            <p className="text-red-600 font-medium">Missing payment reference.</p>
+            <XCircleIcon className="w-12 h-12 text-red-500 dark:text-red-400" />
+            <p className="text-red-600 font-medium dark:text-red-400">Missing payment reference.</p>
             <p className="text-primaryGray text-sm">
               We could not verify your payment because the reference is missing.
             </p>
@@ -86,8 +86,8 @@ export default function VerifyPayment() {
 
         {error && !loading && hasReference && (
           <div className="flex flex-col items-center gap-4">
-            <XCircleIcon className="w-12 h-12 text-red-500" />
-            <p className="text-red-600 font-medium">Payment verification failed.</p>
+            <XCircleIcon className="w-12 h-12 text-red-500 dark:text-red-400" />
+            <p className="text-red-600 font-medium dark:text-red-400">Payment verification failed.</p>
             <p className="text-primaryGray text-sm">
               Please try again or contact support.
             </p>
@@ -97,8 +97,8 @@ export default function VerifyPayment() {
 
         {verificationResult && !loading && !error && hasReference && (
           <div className="flex flex-col items-center gap-4">
-            <CheckCircleIcon className="w-12 h-12 text-green-600" />
-            <p className="text-green-700 font-medium">Payment verified successfully!</p>
+            <CheckCircleIcon className="w-12 h-12 text-green-600 dark:text-green-400" />
+            <p className="text-green-700 font-medium dark:text-green-400">Payment verified successfully!</p>
             <p className="text-primaryGray text-sm">
               Order Reference: <span className="font-mono">{reference}</span>
             </p>


### PR DESCRIPTION
Add dark mode variants for colored UI elements and replace hardcoded hex colors with design system tokens (primaryGray, inputBackground, lightGray, borderGray). Improve responsive layouts and text overflow handling across marketplace and member pages.

## Description
Describe the purpose of this pull request.

## Checklist
- [ ] Tests have been added to all functions
- [ ] Documentation has been updated
- [ ] Changes follow coding standards
