### PR TITLE
fix: category/market/max-price labels invisible on storefront product…

### DIFF
--- a/src/pages/HomePage/Components/reusable/Filter.tsx
+++ b/src/pages/HomePage/Components/reusable/Filter.tsx
@@ -8,6 +8,7 @@ interface FilterProps {
   placeholder?: string;
   size?: number;
   label?: string;
+  labelClassName?: string;
   value?: string;
 }
 
@@ -22,7 +23,9 @@ const Filter: React.FC<FilterProps> = (props) => {
   return (
     <div className={props.className || ""}>
       {props.label ? (
-        <label className="mb-1 block text-sm">{props.label}</label>
+        <label className={`mb-1 block text-sm ${props.labelClassName || ""}`}>
+          {props.label}
+        </label>
       ) : null}
       <select
         name={props.name}

--- a/src/pages/MembersPage/Pages/ProductsPage.tsx
+++ b/src/pages/MembersPage/Pages/ProductsPage.tsx
@@ -149,6 +149,7 @@ export default function ProductsPage() {
           name="category"
           className="sm:w-48"
           label="Category"
+          labelClassName="text-white"
           placeholder="All categories"
           options={[{ label: "All categories", value: "" }, ...categoryOptions]}
           value={selectedCategoryId}
@@ -159,6 +160,7 @@ export default function ProductsPage() {
             name="market"
             className="sm:w-48"
             label="Market"
+            labelClassName="text-white"
             placeholder="All markets"
             options={[{ label: "All markets", value: "" }, ...marketOptions]}
             value={selectedMarketId}
@@ -166,7 +168,7 @@ export default function ProductsPage() {
           />
         )}
         <div className="sm:w-40">
-          <label className="mb-1 block text-sm" htmlFor="max-price">
+          <label className="mb-1 block text-sm text-white" htmlFor="max-price">
             Max price
           </label>
           <input


### PR DESCRIPTION
…s page

The /out/* shell (LandingPage.jsx) paints a dark navy translucent background behind every storefront page. The shared Filter component's label and this page's own "Max price" label never set a text color, so they inherited black and disappeared against it.

Filter is also used on light-background admin pages (OrderFilters, MembersFilter), so its default couldn't change. Added an optional labelClassName prop instead, wired to text-white only from ProductsPage, and fixed the page's own inline Max price label the same way. Scoped to this page only, per request.

## Description
Describe the purpose of this pull request.

## Checklist
- [ ] Tests have been added to all functions
- [ ] Documentation has been updated
- [ ] Changes follow coding standards
