### PR TITLE
feat(orders): redesign member order list + add order detail page

### DIFF
--- a/docs/superpowers/plans/2026-08-20-member-order-view.md
+++ b/docs/superpowers/plans/2026-08-20-member-order-view.md
@@ -1,0 +1,1324 @@
+# Member Order List + Order Detail Page Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Redesign the Members-panel "My Orders" list into order-number-grouped cards and add a real `/member/market/orders/:id` order-detail page, matching the two target screenshots, plus the minimal Backend support (a member-scoped cancel-order endpoint) needed to back it.
+
+**Architecture:** Backend gets one new member-scoped endpoint (`PUT /orders/cancel-order`, mirroring the existing `can_retry_order_payment_scoped` owner-or-admin pattern) and a one-line `findOne` include fix. Frontend gets two new API client functions, a shared order-lifecycle-label helper, a new 3-stage progress stepper component, a new grouped-order-card component (member list only — the shared admin `Orders.tsx`/`MarketOrders.tsx` table is untouched), a new routed `OrderDetailsPage`, and a rewritten `MyOrders.tsx` that drops its Modal in favor of real navigation.
+
+**Tech Stack:** Express + Prisma (Backend), React + TypeScript + Tailwind + react-router-dom v6 (Frontend). No test runner is configured in either repo — verification is manual (curl for Backend, `npm run lint` / `npx tsc --noEmit` / manual click-through for Frontend), per this repo's CLAUDE.md ("No test runner is configured. Do not add test scripts unless asked.").
+
+**Spec:** `docs/superpowers/specs/2026-08-20-member-order-view-design.md`
+
+---
+
+## Task 1: Backend — `can_cancel_order_scoped` authorization middleware
+
+**Files:**
+- Modify: `/Users/akwaah/Documents/GitHub/Backend/src/middleware/authorization.ts:1539-1587` (insert right after `can_retry_order_payment_scoped`, before the `// Users/members` comment on line 1587)
+
+- [ ] **Step 1: Add the middleware**
+
+Insert this new method immediately after the closing `};` of `can_retry_order_payment_scoped` (line 1585), before the blank line + `// Users/members` comment (line 1587):
+
+```ts
+  // Member-initiated order cancellation. Mirrors
+  // can_retry_order_payment_scoped's owner-or-admin pattern: a privileged
+  // Marketplace-manage user may cancel any order; otherwise the caller must
+  // own the order being cancelled.
+  can_cancel_order_scoped = async (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ) => {
+    const errorMessage = "Not authorized to cancel this order";
+    const context = await this.getAccessContext(req, res, errorMessage);
+    if (!context) return;
+
+    const canManageAll =
+      context.isPrivilegedUser &&
+      hasActionPermission(context.permissions, "Marketplace", "manage");
+
+    if (canManageAll) {
+      return next();
+    }
+
+    const rawId = (req as any).body?.id;
+    const orderId = toPositiveInt(rawId);
+
+    if (orderId) {
+      const order = await prisma.orders.findUnique({
+        where: { id: orderId },
+        select: { user_id: true },
+      });
+
+      // Order not found: let the controller's own lookup surface "Order not
+      // found" — this guard only blocks a confirmed cross-owner access.
+      if (order && order.user_id !== context.userId) {
+        return this.unauthorized(res, errorMessage);
+      }
+    }
+
+    return next();
+  };
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `cd /Users/akwaah/Documents/GitHub/Backend && npx tsc --noEmit`
+Expected: no new errors referencing `authorization.ts`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/akwaah/Documents/GitHub/Backend
+git add src/middleware/authorization.ts
+git commit -m "feat(orders): add member-scoped cancel-order authorization
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Backend — `cancelOrder` service method + `findOne` include fix
+
+**Files:**
+- Modify: `/Users/akwaah/Documents/GitHub/Backend/src/modules/orders/orderService.ts:341-347` (`findOne`)
+- Modify: `/Users/akwaah/Documents/GitHub/Backend/src/modules/orders/orderService.ts` (insert `cancelOrder` right after `updateDeliveryStatus`)
+
+- [ ] **Step 1: Add `billing_details` to `findOne`'s include**
+
+Current (lines 341-347):
+```ts
+  async findOne(id: number) {
+    const order = await prisma.orders.findUnique({
+      where: { id },
+      include: { items: true },
+    });
+
+    if (!order) throw new Error("Order not found");
+    return order;
+  }
+```
+
+Change to:
+```ts
+  async findOne(id: number) {
+    const order = await prisma.orders.findUnique({
+      where: { id },
+      include: { items: true, billing_details: true },
+    });
+
+    if (!order) throw new Error("Order not found");
+    return order;
+  }
+```
+
+- [ ] **Step 2: Add `cancelOrder`**
+
+Find `updateDeliveryStatus` (starts at line 546) and its closing `}` (the method ends right before the blank line that precedes the next method). Insert this new method immediately after `updateDeliveryStatus` closes:
+
+```ts
+  async cancelOrder(orderId: number, actorUserId?: number | null) {
+    const order = await prisma.orders.findUnique({ where: { id: orderId } });
+    if (!order) throw new Error("Order not found");
+    if (order.payment_status !== "pending") {
+      throw new Error("Only orders awaiting payment can be cancelled");
+    }
+
+    const updatedOrder = await prisma.orders.update({
+      where: { id: orderId },
+      data: { delivery_status: "cancelled" },
+      include: { items: true, billing_details: true },
+    });
+
+    const recipientUserId = Number(updatedOrder.user_id);
+    if (Number.isInteger(recipientUserId) && recipientUserId > 0) {
+      await notificationService.createInAppNotification({
+        type: "order.cancelled",
+        title: "Order cancelled",
+        body: `Order ${updatedOrder.order_number || `#${updatedOrder.id}`} was cancelled.`,
+        recipientUserId,
+        actorUserId:
+          Number.isInteger(Number(actorUserId)) && Number(actorUserId) > 0
+            ? Number(actorUserId)
+            : null,
+        entityType: "ORDER",
+        entityId: String(updatedOrder.id),
+        actionUrl: "/member/market/orders",
+        priority: "MEDIUM",
+        dedupeKey: `order:${updatedOrder.id}:cancelled`,
+      });
+    }
+
+    return updatedOrder;
+  }
+```
+
+This matches `updateDeliveryStatus`'s notification-call shape exactly (same `notificationService.createInAppNotification` fields, just a `type`/`title`/`body`/`dedupeKey` specific to cancellation).
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `cd /Users/akwaah/Documents/GitHub/Backend && npx tsc --noEmit`
+Expected: no new errors referencing `orderService.ts`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/akwaah/Documents/GitHub/Backend
+git add src/modules/orders/orderService.ts
+git commit -m "feat(orders): add cancelOrder service method
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Backend — `cancelOrder` controller
+
+**Files:**
+- Modify: `/Users/akwaah/Documents/GitHub/Backend/src/modules/orders/orderController.ts` (insert after `updateDeliveryStatus`, before the class's closing `}` on line 281)
+
+- [ ] **Step 1: Add the controller method**
+
+Insert immediately after `updateDeliveryStatus`'s closing `}` (line 280), before the class's closing `}` (line 281):
+
+```ts
+
+  async cancelOrder(req: Request, res: Response) {
+    try {
+      const { id } = req.body as { id?: number | string };
+      const orderId = Number(id);
+      if (!Number.isInteger(orderId) || orderId <= 0) {
+        return res.status(400).json({ message: "A valid order id is required" });
+      }
+
+      const actorUserId = Number((req as any)?.user?.id);
+      const updatedOrder = await orderService.cancelOrder(
+        orderId,
+        Number.isInteger(actorUserId) && actorUserId > 0 ? actorUserId : null,
+      );
+
+      return res.status(200).json({
+        message: "Order cancelled successfully",
+        data: updatedOrder,
+      });
+    } catch (error: any) {
+      return res.status(400).json({
+        message: error.message || "Failed to cancel order",
+      });
+    }
+  }
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `cd /Users/akwaah/Documents/GitHub/Backend && npx tsc --noEmit`
+Expected: no new errors referencing `orderController.ts`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/akwaah/Documents/GitHub/Backend
+git add src/modules/orders/orderController.ts
+git commit -m "feat(orders): add cancelOrder controller
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Backend — route + manual verification
+
+**Files:**
+- Modify: `/Users/akwaah/Documents/GitHub/Backend/src/modules/orders/orderRoutes.ts:659-663` (insert before the existing `/update-delivery-status` route)
+
+- [ ] **Step 1: Add the route**
+
+Insert immediately before the existing `orderRouter.put("/update-delivery-status", ...)` block (line 659):
+
+```ts
+/**
+ * @swagger
+ * /orders/cancel-order:
+ *   put:
+ *     summary: Cancel an order that is still awaiting payment
+ *     tags: [Orders]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - id
+ *             properties:
+ *               id:
+ *                 type: integer
+ *                 example: 42
+ *     responses:
+ *       200:
+ *         description: Order cancelled successfully
+ *       400:
+ *         description: Failed to cancel order
+ */
+orderRouter.put(
+  "/cancel-order",
+  [protect, permissions.can_cancel_order_scoped],
+  orderController.cancelOrder,
+);
+
+```
+
+- [ ] **Step 2: Start the dev server and smoke-test with curl**
+
+Run: `cd /Users/akwaah/Documents/GitHub/Backend && npm run dev` (leave running)
+
+In another shell, log in as a member to get a token, then:
+
+```bash
+# Replace TOKEN with a real member JWT and 42 with a real order id owned by
+# that member, with payment_status still 'pending'.
+curl -i -X PUT http://localhost:8080/orders/cancel-order \
+  -H "Authorization: Bearer TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"id": 42}'
+```
+
+Expected: `200` with `{"message":"Order cancelled successfully","data":{...,"delivery_status":"cancelled",...}}`.
+
+Then verify the ownership guard: repeat with a different member's token against the same order id — expect `401` with `"Not authorized to cancel this order"`.
+
+Then verify the business rule: repeat against an order whose `payment_status` is already `success` — expect `400` with `"Only orders awaiting payment can be cancelled"`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/akwaah/Documents/GitHub/Backend
+git add src/modules/orders/orderRoutes.ts
+git commit -m "feat(orders): route PUT /orders/cancel-order
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Frontend — order-detail types
+
+**Files:**
+- Modify: `/Users/akwaah/Documents/GitHub/Frontend/src/utils/api/marketPlace/interface.ts` (append after `IOrders`, i.e. after line 149)
+
+- [ ] **Step 1: Add `IOrderItem` and `IOrderDetail`**
+
+Insert after the `IOrders` interface (after line 149, before `export interface IProductSlice`):
+
+```ts
+// Unflattened order shape returned by GET /orders/get-order-by-id — one
+// order with a real items[] array, as opposed to IOrders which is one
+// flattened order+item row (mirrors the Backend's flattenOrders output used
+// for order lists).
+export interface IOrderItem {
+  id: number;
+  name: string;
+  image_url: string;
+  color: string;
+  size: string;
+  price_amount: number;
+  price_currency: string;
+  quantity: number;
+  product_type: string;
+  product_category: string;
+}
+
+export interface IOrderBillingDetails {
+  first_name: string;
+  last_name: string;
+  email: string;
+  phone_number: string;
+  country: string;
+}
+
+export interface IOrderDetail {
+  id: number;
+  order_number: string;
+  total_amount: number;
+  payment_status: PaymentStatus;
+  delivery_status: "pending" | "shipped" | "delivered" | "cancelled";
+  created_at: string;
+  reference: string;
+  items: IOrderItem[];
+  billing_details?: IOrderBillingDetails | null;
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `cd /Users/akwaah/Documents/GitHub/Frontend && npx tsc --noEmit`
+Expected: no new errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/akwaah/Documents/GitHub/Frontend
+git add src/utils/api/marketPlace/interface.ts
+git commit -m "feat(orders): add IOrderItem/IOrderDetail types
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Frontend — API client functions
+
+**Files:**
+- Modify: `/Users/akwaah/Documents/GitHub/Frontend/src/utils/api/apiFetch.ts:31-36` (import) and after line 669 (new function)
+- Modify: `/Users/akwaah/Documents/GitHub/Frontend/src/utils/api/apiPut.ts:29-34` (import) and after line 492 (new function)
+
+- [ ] **Step 1: `fetchOrderById` — update the import**
+
+In `apiFetch.ts`, change (lines 31-36):
+```ts
+import type {
+  IMarket,
+  IOrders,
+  IProductType,
+  IProductTypeResponse,
+} from "./marketPlace/interface";
+```
+to:
+```ts
+import type {
+  IMarket,
+  IOrderDetail,
+  IOrders,
+  IProductType,
+  IProductTypeResponse,
+} from "./marketPlace/interface";
+```
+
+- [ ] **Step 2: `fetchOrderById` — add the function**
+
+In `apiFetch.ts`, immediately after `fetchOrdersByUser` (after line 669, before the `// Fetch staff appointment availability` comment on line 671):
+
+```ts
+
+  fetchOrderById = (
+    query?: QueryType
+  ): Promise<ApiResponse<IOrderDetail>> => {
+    return this.fetchFromApi(`orders/get-order-by-id`, query);
+  };
+```
+
+- [ ] **Step 3: `cancelOrder` — update the import**
+
+In `apiPut.ts`, change (lines 29-34):
+```ts
+import type {
+  IMarket,
+  IProductType,
+  IProduct,
+  IOrders,
+} from "./marketPlace/interface";
+```
+to:
+```ts
+import type {
+  IMarket,
+  IProductType,
+  IProduct,
+  IOrders,
+  IOrderDetail,
+} from "./marketPlace/interface";
+```
+
+- [ ] **Step 4: `cancelOrder` — add the function**
+
+In `apiPut.ts`, immediately after `updateOrderDeliveryStatus` (after its closing `};`, before the `// uodate church attendance` comment):
+
+```ts
+
+  cancelOrder = (
+    payload: { id: number | string }
+  ): Promise<ApiResponse<IOrderDetail>> => {
+    return this.apiExecution.updateData("orders/cancel-order", payload);
+  };
+```
+
+- [ ] **Step 5: Verify it compiles**
+
+Run: `cd /Users/akwaah/Documents/GitHub/Frontend && npx tsc --noEmit`
+Expected: no new errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/akwaah/Documents/GitHub/Frontend
+git add src/utils/api/apiFetch.ts src/utils/api/apiPut.ts
+git commit -m "feat(orders): add fetchOrderById/cancelOrder API clients
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Frontend — order lifecycle helper
+
+**Files:**
+- Create: `/Users/akwaah/Documents/GitHub/Frontend/src/pages/MembersPage/utils/orderLifecycle.ts`
+
+- [ ] **Step 1: Write the helper**
+
+```ts
+import type { IOrders, IOrderDetail } from "@/utils";
+
+export type OrderLifecycleStage =
+  | "waiting_payment"
+  | "payment_failed"
+  | "waiting_delivery"
+  | "complete"
+  | "cancelled";
+
+export interface OrderLifecycle {
+  stage: OrderLifecycleStage;
+  label: string;
+  canPay: boolean;
+  canCancel: boolean;
+}
+
+type LifecycleInput = Pick<
+  IOrders | IOrderDetail,
+  "payment_status" | "delivery_status"
+>;
+
+const STAGE_LABELS: Record<OrderLifecycleStage, string> = {
+  waiting_payment: "Waiting for Payment",
+  payment_failed: "Payment Failed",
+  waiting_delivery: "Waiting for Delivery",
+  complete: "Transaction Complete",
+  cancelled: "Order Cancelled",
+};
+
+/**
+ * Single source of truth for order status wording, used by both the
+ * member order list (badges) and the order detail page (progress bar).
+ * There is no separate "Been Shipped" stage — delivery_status === "shipped"
+ * folds into "waiting_delivery" since there is no real shipment-tracking
+ * data model to justify a distinct stage.
+ */
+export function getOrderLifecycle(order: LifecycleInput): OrderLifecycle {
+  const paymentStatus = String(order.payment_status || "").toLowerCase();
+  const deliveryStatus = String(order.delivery_status || "").toLowerCase();
+
+  let stage: OrderLifecycleStage;
+  if (deliveryStatus === "cancelled") {
+    stage = "cancelled";
+  } else if (paymentStatus === "failed") {
+    stage = "payment_failed";
+  } else if (paymentStatus === "pending") {
+    stage = "waiting_payment";
+  } else if (deliveryStatus === "delivered") {
+    stage = "complete";
+  } else {
+    // paid (success), delivery pending or shipped
+    stage = "waiting_delivery";
+  }
+
+  return {
+    stage,
+    label: STAGE_LABELS[stage],
+    canPay: stage === "waiting_payment",
+    canCancel: stage === "waiting_payment",
+  };
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `cd /Users/akwaah/Documents/GitHub/Frontend && npx tsc --noEmit`
+Expected: no new errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/akwaah/Documents/GitHub/Frontend
+git add src/pages/MembersPage/utils/orderLifecycle.ts
+git commit -m "feat(orders): add shared order lifecycle/label helper
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: Frontend — 3-stage order progress stepper
+
+**Files:**
+- Create: `/Users/akwaah/Documents/GitHub/Frontend/src/pages/MembersPage/components/OrderProgressStepper.tsx`
+
+- [ ] **Step 1: Write the component**
+
+Modeled on the existing 5-step `src/pages/HomePage/pages/MarketPlace/components/Orders/OrderStatusTimeline.tsx` (same `cn`/`CheckCircleIcon` visual language), but 3 steps and driven by `OrderLifecycleStage` instead of raw payment/delivery enums:
+
+```tsx
+import { CheckCircleIcon } from "@heroicons/react/24/solid";
+
+import { cn } from "@/utils/cn";
+import type { OrderLifecycleStage } from "@/pages/MembersPage/utils/orderLifecycle";
+
+const STEPS = ["Submit Order", "Waiting for Delivery", "Transaction Complete"] as const;
+
+interface IProps {
+  stage: OrderLifecycleStage;
+}
+
+export function OrderProgressStepper({ stage }: IProps) {
+  if (stage === "cancelled") {
+    return (
+      <p className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm font-medium text-red-600 dark:border-red-900/40 dark:bg-red-900/10 dark:text-red-400">
+        This order was cancelled.
+      </p>
+    );
+  }
+
+  if (stage === "payment_failed") {
+    return (
+      <p className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm font-medium text-red-600 dark:border-red-900/40 dark:bg-red-900/10 dark:text-red-400">
+        Payment failed — this order was not completed.
+      </p>
+    );
+  }
+
+  // Step 0 ("Submit Order") is always complete: the order exists.
+  // Step 1 ("Waiting for Delivery") completes once payment succeeds.
+  // Step 2 ("Transaction Complete") completes once delivery is marked delivered.
+  const completedSteps =
+    stage === "waiting_payment" ? 0 : stage === "waiting_delivery" ? 1 : 2;
+
+  return (
+    <div className="overflow-x-auto">
+      <div className="flex items-center min-w-max">
+        {STEPS.map((step, index) => {
+          const isComplete = index <= completedSteps;
+          const isCurrent = index === completedSteps + 1;
+          const isLast = index === STEPS.length - 1;
+
+          return (
+            <div key={step} className="flex flex-1 items-center last:flex-none">
+              <div className="flex flex-col items-center gap-1">
+                <div
+                  className={cn(
+                    "flex h-6 w-6 items-center justify-center rounded-full border-2 text-xs font-semibold",
+                    isComplete
+                      ? "border-primary bg-primary text-white"
+                      : isCurrent
+                      ? "border-primary text-primary"
+                      : "border-lightGray text-primaryGray"
+                  )}
+                >
+                  {isComplete ? <CheckCircleIcon className="h-4 w-4" /> : index + 1}
+                </div>
+                <span
+                  className={cn(
+                    "whitespace-nowrap text-[11px]",
+                    isComplete || isCurrent ? "font-medium text-primary" : "text-primaryGray"
+                  )}
+                >
+                  {step}
+                </span>
+              </div>
+              {!isLast && (
+                <div
+                  className={cn(
+                    "mx-1 h-0.5 flex-1",
+                    index < completedSteps ? "bg-primary" : "bg-lightGray"
+                  )}
+                />
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `cd /Users/akwaah/Documents/GitHub/Frontend && npx tsc --noEmit`
+Expected: no new errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/akwaah/Documents/GitHub/Frontend
+git add src/pages/MembersPage/components/OrderProgressStepper.tsx
+git commit -m "feat(orders): add 3-stage order progress stepper
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: Frontend — routing
+
+**Files:**
+- Modify: `/Users/akwaah/Documents/GitHub/Frontend/src/utils/const.ts:118` (after `orders:`)
+- Modify: `/Users/akwaah/Documents/GitHub/Frontend/src/routes/appRoutes.tsx:70` (import) and the `orders` child route (around line 1174)
+
+- [ ] **Step 1: Add the path constant**
+
+In `const.ts`, change:
+```ts
+    orders: "/member/market/orders",
+```
+to:
+```ts
+    orders: "/member/market/orders",
+    orderDetails: "/member/market/orders/:id",
+```
+
+- [ ] **Step 2: Import `OrderDetailsPage`**
+
+In `appRoutes.tsx`, immediately after line 70 (`import { MyOrders } from "@/pages/MembersPage/Pages/MyOrders";`):
+```ts
+import { OrderDetailsPage } from "@/pages/MembersPage/Pages/OrderDetailsPage";
+```
+
+- [ ] **Step 3: Add the child route**
+
+In `appRoutes.tsx`, immediately after the existing `orders` child route entry (the block with `path: relativePath.member.orders`, `name: "Orders"`, `element: <MyOrders />`), add a sibling entry:
+
+```ts
+          {
+            path: relativePath.member.orderDetails,
+            name: "Order Details",
+            element: <OrderDetailsPage />,
+            isPrivate: false,
+          },
+```
+
+- [ ] **Step 4: Verify it compiles**
+
+Run: `cd /Users/akwaah/Documents/GitHub/Frontend && npx tsc --noEmit`
+Expected: fails here because `OrderDetailsPage.tsx` doesn't exist yet — that's fine, confirms the import is wired; Task 12 creates the file. Re-run after Task 12 to confirm it passes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/akwaah/Documents/GitHub/Frontend
+git add src/utils/const.ts src/routes/appRoutes.tsx
+git commit -m "feat(orders): add /member/market/orders/:id route
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 10: Frontend — grouped order card (member list)
+
+**Files:**
+- Create: `/Users/akwaah/Documents/GitHub/Frontend/src/pages/MembersPage/components/MemberOrderGroup.tsx`
+
+This renders one order-number block for the member list screenshot: header (date, order number, Pay Now/Cancel Order), stacked product rows, trailing total/status/"View Order" link. It receives the flattened `IOrders[]` rows that share one `order_number` — grouping happens in `MyOrders.tsx` (Task 11).
+
+- [ ] **Step 1: Write the component**
+
+```tsx
+import { Link } from "react-router-dom";
+
+import { Button } from "@/components";
+import { encodeQuery } from "@/pages/HomePage/utils";
+import { relativePath } from "@/utils";
+import type { IOrders } from "@/utils";
+import { getOrderLifecycle } from "@/pages/MembersPage/utils/orderLifecycle";
+
+const formatMoney = (amount: number) => `₵ ${amount.toFixed(2)}`;
+
+const formatOrderDate = (value?: string) => {
+  if (!value) return "";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${pad(date.getDate())}/${pad(date.getMonth() + 1)}/${date.getFullYear()} ${pad(
+    date.getHours()
+  )}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`;
+};
+
+interface IProps {
+  orderNumber: string;
+  rows: IOrders[];
+  onPay: (order: IOrders) => void;
+  onCancel: (order: IOrders) => void;
+  isProcessing: boolean;
+}
+
+export function MemberOrderGroup({
+  orderNumber,
+  rows,
+  onPay,
+  onCancel,
+  isProcessing,
+}: IProps) {
+  const first = rows[0];
+  const lifecycle = getOrderLifecycle(first);
+  const orderTotal = rows.reduce(
+    (sum, row) => sum + Number(row.price_amount || 0) * Number(row.quantity || 0),
+    0
+  );
+  const detailHref = `${relativePath.member.market}orders/${encodeQuery(
+    String(first.order_id ?? first.id)
+  )}`;
+
+  return (
+    <div className="border-b border-lightGray py-4">
+      <div className="flex flex-wrap items-center justify-between gap-3 bg-lightGray/20 px-4 py-3">
+        <div className="space-y-1 text-sm">
+          <p>
+            <span className="text-primaryGray">Order date: </span>
+            <span className="font-semibold text-primary">
+              {formatOrderDate(first.created_at || first.order_created_at || first.ordered_at)}
+            </span>
+          </p>
+          <p>
+            <span className="text-primaryGray">Order NO: </span>
+            <span className="font-semibold text-primary">{orderNumber}</span>
+          </p>
+        </div>
+
+        {(lifecycle.canPay || lifecycle.canCancel) && (
+          <div className="flex items-center gap-2">
+            {lifecycle.canPay && (
+              <Button
+                value="Pay Now"
+                loading={isProcessing}
+                disabled={isProcessing}
+                onClick={() => onPay(first)}
+              />
+            )}
+            {lifecycle.canCancel && (
+              <Button
+                value="Cancel Order"
+                variant="secondary"
+                disabled={isProcessing}
+                onClick={() => onCancel(first)}
+              />
+            )}
+          </div>
+        )}
+      </div>
+
+      <div className="divide-y divide-lightGray/60 px-4">
+        {rows.map((row, index) => {
+          const isLastRow = index === rows.length - 1;
+          return (
+            <div key={`${orderNumber}-${row.id}-${index}`} className="flex gap-4 py-4">
+              <img
+                src={row.image_url}
+                alt={row.name}
+                className="h-16 w-16 flex-shrink-0 rounded-lg border border-lightGray object-cover"
+              />
+
+              <div className="flex-1">
+                <p className="font-medium text-primary">{row.name}</p>
+                <p className="text-sm text-primaryGray">{row.color}</p>
+              </div>
+
+              <div className="w-16 text-center text-sm">
+                <p className="text-primaryGray">Qty</p>
+                <p className="font-semibold text-primary">X{row.quantity}</p>
+              </div>
+
+              <div className="w-24 text-center text-sm">
+                <p className="text-primaryGray">Price</p>
+                <p className="font-semibold text-primary">
+                  {formatMoney(Number(row.price_amount || 0))}
+                </p>
+              </div>
+
+              <div className="w-40 text-right text-sm">
+                {isLastRow && (
+                  <>
+                    <p className="font-semibold text-primary">Total Price:</p>
+                    <p className="text-lg font-bold text-primary">{formatMoney(orderTotal)}</p>
+                    <p className="mt-1 text-primaryGray">{lifecycle.label}</p>
+                    <Link to={detailHref} className="font-medium text-primary underline">
+                      View Order &gt;
+                    </Link>
+                  </>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `cd /Users/akwaah/Documents/GitHub/Frontend && npx tsc --noEmit`
+Expected: no new errors (aside from the still-missing `OrderDetailsPage` import from Task 9, unrelated to this file).
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/akwaah/Documents/GitHub/Frontend
+git add src/pages/MembersPage/components/MemberOrderGroup.tsx
+git commit -m "feat(orders): add grouped order card for member order list
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 11: Frontend — rewrite `MyOrders.tsx`
+
+**Files:**
+- Modify: `/Users/akwaah/Documents/GitHub/Frontend/src/pages/MembersPage/Pages/MyOrders.tsx` (full rewrite)
+
+- [ ] **Step 1: Replace the file contents**
+
+```tsx
+import { useCallback, useMemo, useState } from "react";
+
+import { useFetch } from "@/CustomHooks/useFetch";
+import { PaginationComponent } from "@/pages/HomePage/Components/reusable/PaginationComponent";
+import { showNotification } from "@/pages/HomePage/utils";
+import { MemberOrderGroup } from "@/pages/MembersPage/components/MemberOrderGroup";
+import { api, decodeToken, IOrders, relativePath } from "@/utils";
+import EmptyState from "@/components/EmptyState";
+
+const PAGE_SIZE = 10;
+
+export const MyOrders = () => {
+  const user = decodeToken();
+  const userId = user?.id ? String(user.id) : "";
+  const { data, refetch } = useFetch(
+    api.fetch.fetchOrdersByUser,
+    userId ? { user_id: userId } : undefined,
+    !userId
+  );
+  const [processingOrderKey, setProcessingOrderKey] = useState<string | null>(
+    null
+  );
+  const [page, setPage] = useState(1);
+
+  const memberOrders = useMemo<IOrders[]>(() => {
+    if (!data) return [];
+
+    if (Array.isArray(data)) {
+      return [...data].sort((a, b) => Number(b.id) - Number(a.id));
+    }
+
+    const apiData = (data as { data?: IOrders[] }).data;
+    if (Array.isArray(apiData)) {
+      return [...apiData].sort((a, b) => Number(b.id) - Number(a.id));
+    }
+
+    return [];
+  }, [data]);
+
+  const getOrderKey = useCallback((order: IOrders) => {
+    return String(
+      order.order_number || order.reference || order.order_id || order.id
+    );
+  }, []);
+
+  // Group the flattened one-row-per-line-item rows by order_number, in
+  // descending order (newest order first, preserving memberOrders' sort).
+  const groupedOrders = useMemo(() => {
+    const groups = new Map<string, IOrders[]>();
+    for (const order of memberOrders) {
+      const key = getOrderKey(order);
+      const existing = groups.get(key);
+      if (existing) existing.push(order);
+      else groups.set(key, [order]);
+    }
+    return Array.from(groups.entries()).map(([orderNumber, rows]) => ({
+      orderNumber,
+      rows,
+    }));
+  }, [memberOrders, getOrderKey]);
+
+  const pagedGroups = useMemo(() => {
+    const start = (page - 1) * PAGE_SIZE;
+    return groupedOrders.slice(start, start + PAGE_SIZE);
+  }, [groupedOrders, page]);
+
+  const handleRetryPayment = useCallback(
+    async (selectedOrder: IOrders) => {
+      if ((selectedOrder.payment_status || "").toLowerCase() !== "pending") {
+        showNotification("This order is already paid.", "error");
+        return;
+      }
+
+      const orderKey = getOrderKey(selectedOrder);
+      setProcessingOrderKey(orderKey);
+
+      const retryOrderId = String(selectedOrder.order_id || selectedOrder.id || "").trim();
+      if (!retryOrderId) {
+        showNotification("Unable to process payment for this order.", "error");
+        setProcessingOrderKey(null);
+        return;
+      }
+
+      const payload = {
+        id: retryOrderId,
+        cancellation_url: `${window.location.origin}${relativePath.member.orders}`,
+        return_url: `${window.location.origin}${relativePath.member.verify_payment}`,
+      };
+
+      try {
+        const response = await api.post.retryOrderPayment(payload);
+        const checkoutUrl = response?.data?.checkoutUrl;
+
+        if (!checkoutUrl) {
+          showNotification("Unable to start payment checkout.", "error");
+          return;
+        }
+
+        window.location.href = checkoutUrl;
+      } catch (error: unknown) {
+        const message =
+          typeof error === "object" &&
+          error !== null &&
+          "response" in error &&
+          typeof (error as { response?: { data?: { message?: string } } })
+            .response?.data?.message === "string"
+            ? (error as { response?: { data?: { message?: string } } }).response
+                ?.data?.message
+            : "Failed to initiate payment.";
+
+        showNotification(message || "Failed to initiate payment.", "error");
+      } finally {
+        setProcessingOrderKey(null);
+      }
+    },
+    [getOrderKey]
+  );
+
+  const handleCancelOrder = useCallback(
+    async (selectedOrder: IOrders) => {
+      const orderKey = getOrderKey(selectedOrder);
+      setProcessingOrderKey(orderKey);
+
+      const orderId = String(selectedOrder.order_id || selectedOrder.id || "").trim();
+      if (!orderId) {
+        showNotification("Unable to cancel this order.", "error");
+        setProcessingOrderKey(null);
+        return;
+      }
+
+      try {
+        await api.put.cancelOrder({ id: orderId });
+        showNotification("Order cancelled.", "success");
+        await refetch();
+      } catch (error: unknown) {
+        const message =
+          typeof error === "object" &&
+          error !== null &&
+          "response" in error &&
+          typeof (error as { response?: { data?: { message?: string } } })
+            .response?.data?.message === "string"
+            ? (error as { response?: { data?: { message?: string } } }).response
+                ?.data?.message
+            : "Failed to cancel order.";
+
+        showNotification(message || "Failed to cancel order.", "error");
+      } finally {
+        setProcessingOrderKey(null);
+      }
+    },
+    [getOrderKey, refetch]
+  );
+
+  if (groupedOrders.length === 0) {
+    return <EmptyState scope="page" msg="You have not placed any orders yet" />;
+  }
+
+  return (
+    <div className="rounded-xl bg-white">
+      {pagedGroups.map(({ orderNumber, rows }) => (
+        <MemberOrderGroup
+          key={orderNumber}
+          orderNumber={orderNumber}
+          rows={rows}
+          onPay={handleRetryPayment}
+          onCancel={handleCancelOrder}
+          isProcessing={processingOrderKey === orderNumber}
+        />
+      ))}
+
+      <PaginationComponent
+        total={groupedOrders.length}
+        take={PAGE_SIZE}
+        onPageChange={(newPage) => setPage(newPage)}
+      />
+    </div>
+  );
+};
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `cd /Users/akwaah/Documents/GitHub/Frontend && npx tsc --noEmit`
+Expected: only the still-missing `OrderDetailsPage` error from Task 9 remains.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/akwaah/Documents/GitHub/Frontend
+git add src/pages/MembersPage/Pages/MyOrders.tsx
+git commit -m "feat(orders): regroup member order list by order number
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 12: Frontend — `OrderDetailsPage`
+
+**Files:**
+- Create: `/Users/akwaah/Documents/GitHub/Frontend/src/pages/MembersPage/Pages/OrderDetailsPage.tsx`
+
+- [ ] **Step 1: Write the page**
+
+```tsx
+import { useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+
+import { useFetch } from "@/CustomHooks/useFetch";
+import EmptyState from "@/components/EmptyState";
+import { Skeleton } from "@/components/Skeleton";
+import { Button } from "@/components";
+import { OrderProgressStepper } from "@/pages/MembersPage/components/OrderProgressStepper";
+import { getOrderLifecycle } from "@/pages/MembersPage/utils/orderLifecycle";
+import { decodeQuery, showNotification } from "@/pages/HomePage/utils";
+import { api, relativePath } from "@/utils";
+
+const SUPPORT_EMAIL = "systemadmin@worldwidewordministries.org";
+
+const formatMoney = (amount: number) => `₵ ${amount.toFixed(2)}`;
+
+const formatOrderDate = (value?: string) => {
+  if (!value) return "";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${pad(date.getDate())}/${pad(date.getMonth() + 1)}/${date.getFullYear()} ${pad(
+    date.getHours()
+  )}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`;
+};
+
+export function OrderDetailsPage() {
+  const { id } = useParams();
+  const orderId = decodeQuery(id || "");
+  const navigate = useNavigate();
+  const [isProcessing, setIsProcessing] = useState(false);
+
+  const {
+    data: response,
+    loading,
+    error,
+    refetch,
+  } = useFetch(api.fetch.fetchOrderById, { id: orderId }, !orderId);
+
+  const order = response?.data;
+
+  const handlePay = async () => {
+    if (!order) return;
+    setIsProcessing(true);
+    try {
+      const payload = {
+        id: String(order.id),
+        cancellation_url: `${window.location.origin}${relativePath.member.orders}`,
+        return_url: `${window.location.origin}${relativePath.member.verify_payment}`,
+      };
+      const res = await api.post.retryOrderPayment(payload);
+      const checkoutUrl = res?.data?.checkoutUrl;
+      if (!checkoutUrl) {
+        showNotification("Unable to start payment checkout.", "error");
+        return;
+      }
+      window.location.href = checkoutUrl;
+    } catch {
+      showNotification("Failed to initiate payment.", "error");
+    } finally {
+      setIsProcessing(false);
+    }
+  };
+
+  const handleCancel = async () => {
+    if (!order) return;
+    setIsProcessing(true);
+    try {
+      await api.put.cancelOrder({ id: order.id });
+      showNotification("Order cancelled.", "success");
+      await refetch();
+    } catch {
+      showNotification("Failed to cancel order.", "error");
+    } finally {
+      setIsProcessing(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="space-y-4 p-6" aria-busy="true" aria-live="polite">
+        <Skeleton className="h-8 w-64" />
+        <Skeleton className="h-24 w-full" />
+        <Skeleton className="h-40 w-full" />
+      </div>
+    );
+  }
+
+  if (!order) {
+    return (
+      <EmptyState
+        scope="page"
+        msg={error ? "Failed to load this order" : "Order not found"}
+        actionLabel="Back to orders"
+        onAction={() => navigate(relativePath.member.orders)}
+      />
+    );
+  }
+
+  const lifecycle = getOrderLifecycle(order);
+  const subtotal = order.items.reduce(
+    (sum, item) => sum + Number(item.price_amount || 0) * Number(item.quantity || 0),
+    0
+  );
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-6 rounded-xl bg-white p-6">
+      <div className="flex flex-wrap items-center justify-between gap-4 rounded-lg bg-lightGray/20 p-4">
+        <div>
+          <p className="text-lg font-semibold text-primary">{lifecycle.label}</p>
+          <p className="text-sm text-primaryGray">
+            Order date: <span className="font-medium text-primary">{formatOrderDate(order.created_at)}</span>
+          </p>
+          <p className="text-sm text-primaryGray">
+            Order NO: <span className="font-medium text-primary">{order.order_number}</span>
+          </p>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2">
+          <Button
+            value="Contact Us"
+            variant="secondary"
+            onClick={() => {
+              window.location.href = `mailto:${SUPPORT_EMAIL}?subject=${encodeURIComponent(
+                `Order ${order.order_number}`
+              )}`;
+            }}
+          />
+          {lifecycle.canCancel && (
+            <Button
+              value="Cancel Order"
+              variant="secondary"
+              disabled={isProcessing}
+              onClick={handleCancel}
+            />
+          )}
+          {lifecycle.canPay && (
+            <Button value="Pay Now" loading={isProcessing} disabled={isProcessing} onClick={handlePay} />
+          )}
+        </div>
+      </div>
+
+      <OrderProgressStepper stage={lifecycle.stage} />
+
+      <div className="rounded-lg bg-lightGray/20 p-4 text-sm text-primaryGray">
+        Sorry, there is no shipping information yet
+      </div>
+
+      <div className="divide-y divide-lightGray/60 rounded-lg border border-lightGray">
+        {order.items.map((item, index) => (
+          <div key={`${item.id}-${index}`} className="flex gap-4 p-4">
+            <img
+              src={item.image_url}
+              alt={item.name}
+              className="h-16 w-16 flex-shrink-0 rounded-lg border border-lightGray object-cover"
+            />
+            <div className="flex-1">
+              <p className="font-medium text-primary">{item.name}</p>
+              <p className="text-sm text-primaryGray">{item.color}</p>
+            </div>
+            <div className="w-16 text-center text-sm">
+              <p className="text-primaryGray">Qty</p>
+              <p className="font-semibold text-primary">X{item.quantity}</p>
+            </div>
+            <div className="w-24 text-right text-sm">
+              <p className="text-primaryGray">Price</p>
+              <p className="font-semibold text-primary">{formatMoney(Number(item.price_amount || 0))}</p>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="ml-auto w-full max-w-xs space-y-2 text-sm">
+        <p className="flex items-center justify-between">
+          <span className="text-primaryGray">Subtotal</span>
+          <span className="font-medium text-primary">{formatMoney(subtotal)}</span>
+        </p>
+        <p className="flex items-center justify-between border-t border-lightGray pt-2 text-base">
+          <span className="font-semibold text-primary">Order Total</span>
+          <span className="font-bold text-primary">{formatMoney(Number(order.total_amount || 0))}</span>
+        </p>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `cd /Users/akwaah/Documents/GitHub/Frontend && npx tsc --noEmit`
+Expected: no errors anywhere in the touched files (this resolves the dangling import from Task 9).
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/akwaah/Documents/GitHub/Frontend
+git add src/pages/MembersPage/Pages/OrderDetailsPage.tsx
+git commit -m "feat(orders): add OrderDetailsPage
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 13: Final verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Full typecheck**
+
+Run: `cd /Users/akwaah/Documents/GitHub/Frontend && npx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 2: Lint**
+
+Run: `cd /Users/akwaah/Documents/GitHub/Frontend && npm run lint`
+Expected: passes with `--max-warnings 0`. Fix any `no-console`/unused-var findings inline (prefix truly-unused args with `_`).
+
+- [ ] **Step 3: Manual click-through**
+
+Run: `cd /Users/akwaah/Documents/GitHub/Frontend && npm run dev`
+
+- Log in as a member with at least one order in each state (`pending` payment, `success`+`pending` delivery, `success`+`delivered`, and one `cancelled` if available) — use the Backend curl from Task 4 to force a cancelled one if needed.
+- Visit `/member/market/orders` — confirm order blocks group correctly by order number, Pay Now/Cancel Order only show for the pending-payment order, and "View Order" navigates to `/member/market/orders/:id`.
+- On the detail page, confirm: header label matches lifecycle, stepper shows the right stage (or the cancelled/failed banner), the "no shipping information" box always renders, the product table lists every item with correct qty/price, Subtotal + Order Total compute correctly, and Contact Us opens a mailto to `systemadmin@worldwidewordministries.org`.
+- Click Cancel Order on a pending-payment order and confirm it flips to "Order Cancelled" and disappears from the actionable set.
+
+- [ ] **Step 4: Final commit (if manual fixes were needed)**
+
+```bash
+cd /Users/akwaah/Documents/GitHub/Frontend
+git add -A
+git commit -m "fix(orders): address lint/manual-QA findings
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>"
+```

--- a/docs/superpowers/specs/2026-08-20-member-order-view-design.md
+++ b/docs/superpowers/specs/2026-08-20-member-order-view-design.md
@@ -1,0 +1,184 @@
+# Member Order List + Order Detail Page — Design
+
+Date: 2026-08-20
+Status: Approved (pre-implementation)
+
+## Goal
+
+Redesign the Members-panel "My Orders" list and add a real "View Order" detail
+page, matching two supplied target screenshots:
+
+1. Orders list — order blocks grouped by order number, each with a header
+   (order date, order number, Pay Now / Cancel Order), stacked product rows
+   (image, name, variant, qty, price), and a trailing total/status/"View
+   Order" link.
+2. Order detail — status icon + label, order date/number, Contact Us / Cancel
+   Order / Pay Now actions, a horizontal step progress bar, a shipping-info
+   box, a product table, and a price breakdown block.
+
+## Decisions (resolved during brainstorming)
+
+| # | Question | Decision |
+|---|---|---|
+| 1 | Route vs modal for order detail | **Real routed page** at `/member/market/orders/:id`, not a modal. |
+| 2 | Price breakdown fields (Subtotal/Shipping/Discount/Rounding/Total) — none exist in the data model | **Only Subtotal (computed) + Order Total (`total_amount`)**. Shipping & Handling / Discount / Rounding rows are dropped entirely — no fabricated numbers. |
+| 3 | "Contact Us" button — no support feature exists | `mailto:` link, prefilled subject with the order number. |
+| 4 | Support email address | `systemadmin@worldwidewordministries.org` (confirmed by user; not otherwise present in the codebase). |
+| 5 | "Cancel Order" authorization — existing `update-delivery-status` endpoint is admin-only (`can_manage_marketplace`) | **New member-scoped Backend endpoint** `PUT /orders/cancel-order`, mirroring the existing `can_retry_order_payment_scoped` owner-or-admin pattern. Not a relaxation of the admin endpoint. |
+| 6 | Step progress bar stages — no real shipping/tracking data model exists | **3 stages**: `Submit Order → Waiting for Delivery → Transaction Complete`. No separate "Been Shipped" stage; `delivery_status='shipped'` folds into "Waiting for Delivery". |
+| 7 | Shipping-info box content | Always renders "Sorry, there is no shipping information yet" — there is no address/tracking data anywhere in the schema to show instead. Real shipment tracking is out of scope for this change. |
+
+## Scope boundary
+
+The target screenshots are the **member-facing storefront** view (note the
+public shop nav bar: All Products / Audio / Power / …). This work touches:
+
+- `src/pages/MembersPage/Pages/MyOrders.tsx` (list — member-facing)
+- A new `src/pages/MembersPage/Pages/OrderDetailsPage.tsx` (detail — member-facing)
+
+It explicitly does **not** touch the shared admin/staff order views
+(`src/pages/HomePage/pages/MarketPlace/components/Orders/Orders.tsx`,
+`MarketOrders.tsx`, `OrdersTableColumns.tsx`), which stay on their current
+table/card layout. A new member-only presentational component is added for
+the grouped card list rather than reworking the shared `Orders.tsx`, to avoid
+collateral changes to the admin table.
+
+## Backend changes
+
+### 1. `findOne` — minor parity fix
+
+`orderService.findOne(id)` currently includes only `items`. Add
+`billing_details` to its `include`, matching `updateDeliveryStatus`'s include
+shape, so the detail page has billing/customer info available if ever needed.
+No route/permission change — `GET /orders/get-order-by-id` is already
+protected by `[protect, can_view_orders_scoped]`, which already allows the
+order's owner (see `can_view_orders_scoped` in `authorization.ts`).
+
+### 2. New endpoint: `PUT /orders/cancel-order`
+
+- Route: `orderRouter.put("/cancel-order", [protect, permissions.can_cancel_order_scoped], orderController.cancelOrder)`
+- New middleware `can_cancel_order_scoped` in `authorization.ts`, copied from
+  `can_retry_order_payment_scoped`'s shape:
+  - Privileged user with `Marketplace`/`manage` → allowed.
+  - Otherwise, look up the order by `id` (numeric) from `req.body.id`; if
+    `order.user_id !== context.userId` → 401 "Not authorized to cancel this
+    order". Order-not-found is left to the controller to surface.
+- New controller `orderController.cancelOrder(req, res)`: reads `{ id }` from
+  body, calls `orderService.cancelOrder(id, req.user?.id)`, returns 200 with
+  the updated order or a 400 with `error.message` on failure.
+- New service `orderService.cancelOrder(orderId, actorUserId?)`:
+  - Loads the order; throws `"Order not found"` if missing.
+  - Throws `"Only orders awaiting payment can be cancelled"` if
+    `payment_status !== 'pending'`.
+  - `prisma.orders.update({ where: { id: orderId }, data: { delivery_status: 'cancelled' }, include: { items: true, billing_details: true } })`.
+  - Emits an in-app notification via `notificationService.createInAppNotification`
+    (same pattern as `updateDeliveryStatus`), type `"order.cancelled"`.
+  - Returns the updated order.
+
+No Prisma migration needed — reuses the existing `cancelled` value of the
+`delivery_status` enum.
+
+## Frontend changes
+
+### API clients
+
+- `src/utils/api/apiFetch.ts`: add
+  `fetchOrderById = (id: string | number): Promise<ApiResponse<...>> =>
+  instance.get(\`orders/get-order-by-id\`, { params: { id } })`.
+- `src/utils/api/apiPut.ts`: add
+  `cancelOrder = (payload: { id: string | number }): Promise<ApiResponse<...>> =>
+  instance.put(\`orders/cancel-order\`, payload)`.
+
+### Types
+
+Add an unflattened order-detail shape (distinct from the existing flattened
+`IOrders` list-row type) in `src/utils/api/marketPlace/interface.ts`, e.g.:
+
+```ts
+export interface IOrderItem {
+  id: number;
+  name: string;
+  image_url: string;
+  color: string;
+  size: string;
+  price_amount: number;
+  price_currency: string;
+  quantity: number;
+  product_type: string;
+  product_category: string;
+}
+
+export interface IOrderDetail {
+  id: number;
+  order_number: string;
+  total_amount: number;
+  payment_status: PaymentStatus;
+  delivery_status: "pending" | "shipped" | "delivered" | "cancelled";
+  created_at: string;
+  reference: string;
+  items: IOrderItem[];
+  billing_details?: {
+    first_name: string; last_name: string; email: string;
+    phone_number: string; country: string;
+  } | null;
+}
+```
+
+### Shared status-mapping helper
+
+New small module (e.g. `src/pages/MembersPage/utils/orderLifecycle.ts`) with
+one function used by both the list and the detail page:
+
+```ts
+type LifecycleStage = "waiting_payment" | "payment_failed" | "waiting_delivery" | "complete" | "cancelled";
+
+function getOrderLifecycle(order: { payment_status; delivery_status }): {
+  stage: LifecycleStage;
+  label: string;       // "Waiting for Payment" | "Payment Failed" | "Waiting for Delivery" | "Transaction Complete" | "Order Cancelled"
+  canPay: boolean;     // payment_status === 'pending'
+  canCancel: boolean;  // payment_status === 'pending'
+}
+```
+
+Stepper steps (`Submit Order`, `Waiting for Delivery`, `Transaction
+Complete`) are derived from `stage`: `Submit Order` always complete;
+`Waiting for Delivery` complete once stage is `waiting_delivery` or later;
+`Transaction Complete` complete once stage === `complete`. `cancelled` stage
+bypasses the stepper and shows a standalone "Order Cancelled" banner instead.
+
+### Routing
+
+- `src/utils/const.ts`: add `orderDetails: "/member/market/orders/:id"` under
+  the `member` group.
+- `src/routes/appRoutes.tsx`: add a child route under the existing `orders`
+  parent (or sibling) rendering `<OrderDetailsPage />` at
+  `relativePath.member.orderDetails`.
+
+### Components
+
+- **`MyOrders.tsx`**: replace the current `Modal` + shared `Orders` grid with
+  a new grouped list: group the flattened `IOrders[]` rows by `order_number`
+  into blocks, render each block with the new card header (date, order
+  number, Pay Now/Cancel Order gated by `canPay`/`canCancel`) and stacked
+  product rows, ending in a total + status + "View Order" link that
+  navigates to `relativePath.member.orderDetails` built with that order's id.
+  `handleRetryPayment` (existing Pay Now logic) and a new `handleCancelOrder`
+  (calls `cancelOrder`, then refetches) are wired to the header buttons.
+- **`OrderDetailsPage.tsx`** (new): reads `:id` from the route, calls
+  `fetchOrderById`, renders: status icon/label header with action buttons
+  (Contact Us always; Pay Now/Cancel Order gated by `canPay`/`canCancel`),
+  the 3-stage progress bar (or cancelled banner), the static shipping-info
+  placeholder box, a product table (image/name/variant/qty/price per
+  `items[]`), and the price block (Subtotal computed from `items`, Order
+  Total from `total_amount`).
+- Currency is rendered inline as `₵ {amount.toFixed(2)}` in the new
+  components only (matches the screenshots); no app-wide currency formatter
+  refactor.
+
+## Out of scope
+
+- Real shipping/tracking data (address capture, carrier, tracking number).
+- Backend Shipping/Discount/Rounding fields or migration.
+- Changes to the admin/staff order views (`Orders.tsx`, `MarketOrders.tsx`,
+  `OrdersTableColumns.tsx`).
+- A general in-app "Contact/Support" feature beyond the `mailto:` link.

--- a/src/pages/MembersPage/Pages/MyOrders.tsx
+++ b/src/pages/MembersPage/Pages/MyOrders.tsx
@@ -1,32 +1,43 @@
 import { useCallback, useMemo, useState } from "react";
-import { ColumnDef } from "@tanstack/react-table";
 
 import { useFetch } from "@/CustomHooks/useFetch";
-import { Button } from "@/components";
-import { Modal } from "@/components/Modal";
-import { Orders } from "@/pages/HomePage/pages/MarketPlace/components/Orders/Orders";
-import { getBaseOrderColumns } from "@/pages/HomePage/pages/MarketPlace/components/Orders/OrdersTableColumns";
-import { OrderStatusTimeline } from "@/pages/HomePage/pages/MarketPlace/components/Orders/OrderStatusTimeline";
+import { PaginationComponent } from "@/pages/HomePage/Components/reusable/PaginationComponent";
 import { showNotification } from "@/pages/HomePage/utils";
-import {
-  api,
-  decodeToken,
-  IOrders,
-  relativePath,
-} from "@/utils";
+import { MemberOrderGroup } from "@/pages/MembersPage/components/MemberOrderGroup";
+import { api, decodeToken, IOrders, relativePath } from "@/utils";
+import EmptyState from "@/components/EmptyState";
+import { Skeleton } from "@/components/Skeleton";
+
+const PAGE_SIZE = 10;
 
 export const MyOrders = () => {
   const user = decodeToken();
   const userId = user?.id ? String(user.id) : "";
-  const { data } = useFetch(
+  const { data, loading, error, refetch } = useFetch(
     api.fetch.fetchOrdersByUser,
     userId ? { user_id: userId } : undefined,
     !userId
   );
-  const [processingOrderKey, setProcessingOrderKey] = useState<string | null>(
-    null
+  const [processingKeys, setProcessingKeys] = useState<Set<string>>(
+    new Set()
   );
-  const [viewingOrder, setViewingOrder] = useState<IOrders | null>(null);
+  const [page, setPage] = useState(1);
+
+  const markProcessing = useCallback((key: string) => {
+    setProcessingKeys((prev) => {
+      const next = new Set(prev);
+      next.add(key);
+      return next;
+    });
+  }, []);
+
+  const unmarkProcessing = useCallback((key: string) => {
+    setProcessingKeys((prev) => {
+      const next = new Set(prev);
+      next.delete(key);
+      return next;
+    });
+  }, []);
 
   const memberOrders = useMemo<IOrders[]>(() => {
     if (!data) return [];
@@ -49,6 +60,36 @@ export const MyOrders = () => {
     );
   }, []);
 
+  // Group the flattened one-row-per-line-item rows by order_number, in
+  // descending order (newest order first, preserving memberOrders' sort).
+  const groupedOrders = useMemo(() => {
+    const groups = new Map<string, IOrders[]>();
+    for (const order of memberOrders) {
+      const key = getOrderKey(order);
+      const existing = groups.get(key);
+      if (existing) existing.push(order);
+      else groups.set(key, [order]);
+    }
+    return Array.from(groups.entries()).map(([orderNumber, rows]) => ({
+      orderNumber,
+      rows,
+    }));
+  }, [memberOrders, getOrderKey]);
+
+  const totalPages = useMemo(
+    () => Math.max(1, Math.ceil(groupedOrders.length / PAGE_SIZE)),
+    [groupedOrders.length]
+  );
+  // groupedOrders can shrink out from under `page` (e.g. cancelling the only
+  // order on the last page) without `page` itself being re-clamped, so slice
+  // using an effective page that's always within range.
+  const effectivePage = Math.min(page, totalPages);
+
+  const pagedGroups = useMemo(() => {
+    const start = (effectivePage - 1) * PAGE_SIZE;
+    return groupedOrders.slice(start, start + PAGE_SIZE);
+  }, [groupedOrders, effectivePage]);
+
   const handleRetryPayment = useCallback(
     async (selectedOrder: IOrders) => {
       if ((selectedOrder.payment_status || "").toLowerCase() !== "pending") {
@@ -57,12 +98,12 @@ export const MyOrders = () => {
       }
 
       const orderKey = getOrderKey(selectedOrder);
-      setProcessingOrderKey(orderKey);
+      markProcessing(orderKey);
 
       const retryOrderId = String(selectedOrder.order_id || selectedOrder.id || "").trim();
       if (!retryOrderId) {
         showNotification("Unable to process payment for this order.", "error");
-        setProcessingOrderKey(null);
+        unmarkProcessing(orderKey);
         return;
       }
 
@@ -95,125 +136,109 @@ export const MyOrders = () => {
 
         showNotification(message || "Failed to initiate payment.", "error");
       } finally {
-        setProcessingOrderKey(null);
+        unmarkProcessing(orderKey);
       }
     },
-    [getOrderKey]
+    [getOrderKey, markProcessing, unmarkProcessing]
   );
 
-  const tableColumns = useMemo(() => {
-    const actionColumn: ColumnDef<IOrders> = {
-      header: "Action",
-      cell: ({ row }) => {
-        const order = row.original;
-        const orderKey = getOrderKey(order);
-        const isPending = (order.payment_status || "").toLowerCase() === "pending";
+  const handleCancelOrder = useCallback(
+    async (selectedOrder: IOrders) => {
+      const orderKey = getOrderKey(selectedOrder);
+      markProcessing(orderKey);
 
-        if (!isPending) {
-          return <span className="text-xs text-gray-400">Paid</span>;
-        }
+      const orderId = String(selectedOrder.order_id || selectedOrder.id || "").trim();
+      if (!orderId) {
+        showNotification("Unable to cancel this order.", "error");
+        unmarkProcessing(orderKey);
+        return;
+      }
 
-        return (
-          <Button
-            value="Pay now"
-            className="min-h-8 px-3 py-1 text-xs"
-            loading={processingOrderKey === orderKey}
-            disabled={processingOrderKey !== null}
-            onClick={(e) => {
-              e?.stopPropagation?.();
-              handleRetryPayment(order);
-            }}
-          />
-        );
-      },
-    };
+      try {
+        await api.put.cancelOrder({ id: orderId });
+        showNotification("Order cancelled.", "success");
+        await refetch();
+      } catch (error: unknown) {
+        const message =
+          typeof error === "object" &&
+          error !== null &&
+          "response" in error &&
+          typeof (error as { response?: { data?: { message?: string } } })
+            .response?.data?.message === "string"
+            ? (error as { response?: { data?: { message?: string } } }).response
+                ?.data?.message
+            : "Failed to cancel order.";
 
-    return getBaseOrderColumns([actionColumn]);
-  }, [getOrderKey, handleRetryPayment, processingOrderKey]);
+        showNotification(message || "Failed to cancel order.", "error");
+      } finally {
+        unmarkProcessing(orderKey);
+      }
+    },
+    [getOrderKey, markProcessing, unmarkProcessing, refetch]
+  );
+
+  if (loading) {
+    return <OrdersSkeleton />;
+  }
+
+  if (error) {
+    return <EmptyState scope="page" msg="Failed to load your orders" />;
+  }
+
+  if (groupedOrders.length === 0) {
+    return <EmptyState scope="page" msg="You have not placed any orders yet" />;
+  }
 
   return (
-    <>
-      <Orders
-        orders={memberOrders}
-        tableColumns={tableColumns}
-        searchCustomer={false}
-        defaultMarketStatus="active"
-        onRowClick={(order) => setViewingOrder(order)}
-        renderOrderAction={(order) => {
-          const orderKey = getOrderKey(order);
-          const isPending = (order.payment_status || "").toLowerCase() === "pending";
+    <div className="rounded-xl bg-white">
+      {pagedGroups.map(({ orderNumber, rows }) => (
+        <MemberOrderGroup
+          key={orderNumber}
+          orderNumber={orderNumber}
+          rows={rows}
+          onPay={handleRetryPayment}
+          onCancel={handleCancelOrder}
+          isProcessing={processingKeys.has(orderNumber)}
+        />
+      ))}
 
-          if (!isPending) {
-            return <p className="text-xs text-gray-500">Payment completed</p>;
-          }
-
-          return (
-            <Button
-              value="Pay now"
-              className="w-full"
-              loading={processingOrderKey === orderKey}
-              disabled={processingOrderKey !== null}
-              onClick={() => handleRetryPayment(order)}
-            />
-          );
-        }}
+      <PaginationComponent
+        total={groupedOrders.length}
+        take={PAGE_SIZE}
+        onPageChange={(newPage) => setPage(newPage)}
       />
-
-      <Modal
-        open={Boolean(viewingOrder)}
-        persist={false}
-        onClose={() => setViewingOrder(null)}
-        className="max-w-lg"
-      >
-        {viewingOrder && (
-          <div className="space-y-5 p-6 text-primary">
-            <div>
-              <h3 className="text-lg font-bold">{viewingOrder.order_number}</h3>
-              <p className="text-sm text-primaryGray">
-                {viewingOrder.name} · Qty {viewingOrder.quantity}
-              </p>
-            </div>
-
-            <OrderStatusTimeline
-              paymentStatus={viewingOrder.payment_status}
-              deliveryStatus={viewingOrder.delivery_status}
-            />
-
-            <div className="rounded-lg border border-lightGray p-4 space-y-1 text-sm">
-              <p className="flex items-center justify-between gap-3">
-                <span className="font-medium">Total</span>
-                <span className="min-w-0 break-words text-right">
-                  GHC{" "}
-                  {(
-                    Number(viewingOrder.price_amount || 0) *
-                    Number(viewingOrder.quantity || 0)
-                  ).toFixed(2)}
-                </span>
-              </p>
-              <p className="flex items-center justify-between gap-3">
-                <span className="font-medium">Billed to</span>
-                <span className="min-w-0 break-words text-right">
-                  {viewingOrder.first_name} {viewingOrder.last_name}
-                </span>
-              </p>
-              <p className="flex items-center justify-between gap-3">
-                <span className="font-medium">Email</span>
-                <span className="min-w-0 break-words text-right">{viewingOrder.email}</span>
-              </p>
-            </div>
-
-            {(viewingOrder.payment_status || "").toLowerCase() === "pending" && (
-              <Button
-                value="Pay now"
-                className="w-full"
-                loading={processingOrderKey === getOrderKey(viewingOrder)}
-                disabled={processingOrderKey !== null}
-                onClick={() => handleRetryPayment(viewingOrder)}
-              />
-            )}
-          </div>
-        )}
-      </Modal>
-    </>
+    </div>
   );
 };
+
+function OrdersSkeleton({ count = 3 }: { count?: number }) {
+  return (
+    <div
+      className="rounded-xl bg-white"
+      aria-busy="true"
+      aria-live="polite"
+      aria-label="Loading your orders"
+    >
+      {Array.from({ length: count }).map((_, index) => (
+        <div key={index} className="border-b border-lightGray py-4">
+          <div className="flex flex-wrap items-center justify-between gap-3 bg-lightGray/20 px-4 py-3">
+            <div className="space-y-2">
+              <Skeleton className="h-3 w-32" />
+              <Skeleton className="h-3 w-24" />
+            </div>
+            <Skeleton className="h-9 w-24 rounded-lg" />
+          </div>
+
+          <div className="flex gap-4 px-4 py-4">
+            <Skeleton className="h-16 w-16 flex-shrink-0 rounded-lg" />
+            <div className="flex-1 space-y-2">
+              <Skeleton className="h-4 w-1/2" />
+              <Skeleton className="h-3 w-1/3" />
+            </div>
+          </div>
+        </div>
+      ))}
+      <span className="sr-only">Loading your orders…</span>
+    </div>
+  );
+}

--- a/src/pages/MembersPage/Pages/OrderDetailsPage.tsx
+++ b/src/pages/MembersPage/Pages/OrderDetailsPage.tsx
@@ -1,0 +1,185 @@
+import { useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+
+import { useFetch } from "@/CustomHooks/useFetch";
+import EmptyState from "@/components/EmptyState";
+import { Skeleton } from "@/components/Skeleton";
+import { Button } from "@/components";
+import { OrderProgressStepper } from "@/pages/MembersPage/components/OrderProgressStepper";
+import { getOrderLifecycle } from "@/pages/MembersPage/utils/orderLifecycle";
+import { decodeQuery, showNotification } from "@/pages/HomePage/utils";
+import { api, relativePath } from "@/utils";
+
+const SUPPORT_EMAIL = "systemadmin@worldwidewordministries.org";
+
+const formatMoney = (amount: number) => `₵ ${amount.toFixed(2)}`;
+
+const formatOrderDate = (value?: string) => {
+  if (!value) return "";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${pad(date.getDate())}/${pad(date.getMonth() + 1)}/${date.getFullYear()} ${pad(
+    date.getHours()
+  )}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`;
+};
+
+export function OrderDetailsPage() {
+  const { id } = useParams();
+  const orderId = decodeQuery(id || "");
+  const navigate = useNavigate();
+  const [isProcessing, setIsProcessing] = useState(false);
+
+  const {
+    data: response,
+    loading,
+    error,
+    refetch,
+  } = useFetch(api.fetch.fetchOrderById, { id: orderId }, !orderId);
+
+  const order = response?.data;
+
+  const handlePay = async () => {
+    if (!order) return;
+    setIsProcessing(true);
+    try {
+      const payload = {
+        id: String(order.id),
+        cancellation_url: `${window.location.origin}${relativePath.member.orders}`,
+        return_url: `${window.location.origin}${relativePath.member.verify_payment}`,
+      };
+      const res = await api.post.retryOrderPayment(payload);
+      const checkoutUrl = res?.data?.checkoutUrl;
+      if (!checkoutUrl) {
+        showNotification("Unable to start payment checkout.", "error");
+        return;
+      }
+      window.location.href = checkoutUrl;
+    } catch {
+      showNotification("Failed to initiate payment.", "error");
+    } finally {
+      setIsProcessing(false);
+    }
+  };
+
+  const handleCancel = async () => {
+    if (!order) return;
+    setIsProcessing(true);
+    try {
+      await api.put.cancelOrder({ id: order.id });
+      showNotification("Order cancelled.", "success");
+      await refetch();
+    } catch {
+      showNotification("Failed to cancel order.", "error");
+    } finally {
+      setIsProcessing(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="space-y-4 p-6" aria-busy="true" aria-live="polite">
+        <Skeleton className="h-8 w-64" />
+        <Skeleton className="h-24 w-full" />
+        <Skeleton className="h-40 w-full" />
+      </div>
+    );
+  }
+
+  if (!order) {
+    return (
+      <EmptyState
+        scope="page"
+        msg={error ? "Failed to load this order" : "Order not found"}
+        actionLabel="Back to orders"
+        onAction={() => navigate(relativePath.member.orders)}
+      />
+    );
+  }
+
+  const lifecycle = getOrderLifecycle(order);
+  const subtotal = order.items.reduce(
+    (sum, item) => sum + Number(item.price_amount || 0) * Number(item.quantity || 0),
+    0
+  );
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-6 rounded-xl bg-white p-6">
+      <div className="flex flex-wrap items-center justify-between gap-4 rounded-lg bg-lightGray/20 p-4">
+        <div>
+          <p className="text-lg font-semibold text-primary">{lifecycle.label}</p>
+          <p className="text-sm text-primaryGray">
+            Order date: <span className="font-medium text-primary">{formatOrderDate(order.created_at)}</span>
+          </p>
+          <p className="text-sm text-primaryGray">
+            Order NO: <span className="font-medium text-primary">{order.order_number}</span>
+          </p>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2">
+          <Button
+            value="Contact Us"
+            variant="secondary"
+            onClick={() => {
+              window.location.href = `mailto:${SUPPORT_EMAIL}?subject=${encodeURIComponent(
+                `Order ${order.order_number}`
+              )}`;
+            }}
+          />
+          {lifecycle.canCancel && (
+            <Button
+              value="Cancel Order"
+              variant="secondary"
+              disabled={isProcessing}
+              onClick={handleCancel}
+            />
+          )}
+          {lifecycle.canPay && (
+            <Button value="Pay Now" loading={isProcessing} disabled={isProcessing} onClick={handlePay} />
+          )}
+        </div>
+      </div>
+
+      <OrderProgressStepper stage={lifecycle.stage} />
+
+      <div className="rounded-lg bg-lightGray/20 p-4 text-sm text-primaryGray">
+        Sorry, there is no shipping information yet
+      </div>
+
+      <div className="divide-y divide-lightGray/60 rounded-lg border border-lightGray">
+        {order.items.map((item, index) => (
+          <div key={`${item.id}-${index}`} className="flex gap-4 p-4">
+            <img
+              src={item.image_url}
+              alt={item.name}
+              className="h-16 w-16 flex-shrink-0 rounded-lg border border-lightGray object-cover"
+            />
+            <div className="flex-1">
+              <p className="font-medium text-primary">{item.name}</p>
+              <p className="text-sm text-primaryGray">{item.color}</p>
+            </div>
+            <div className="w-16 text-center text-sm">
+              <p className="text-primaryGray">Qty</p>
+              <p className="font-semibold text-primary">X{item.quantity}</p>
+            </div>
+            <div className="w-24 text-right text-sm">
+              <p className="text-primaryGray">Price</p>
+              <p className="font-semibold text-primary">{formatMoney(Number(item.price_amount || 0))}</p>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="ml-auto w-full max-w-xs space-y-2 text-sm">
+        <p className="flex items-center justify-between">
+          <span className="text-primaryGray">Subtotal</span>
+          <span className="font-medium text-primary">{formatMoney(subtotal)}</span>
+        </p>
+        <p className="flex items-center justify-between border-t border-lightGray pt-2 text-base">
+          <span className="font-semibold text-primary">Order Total</span>
+          <span className="font-bold text-primary">{formatMoney(Number(order.total_amount || 0))}</span>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/MembersPage/Pages/OrderDetailsPage.tsx
+++ b/src/pages/MembersPage/Pages/OrderDetailsPage.tsx
@@ -104,8 +104,8 @@ export function OrderDetailsPage() {
   );
 
   return (
-    <div className="mx-auto max-w-4xl space-y-6 rounded-xl bg-white p-6">
-      <div className="flex flex-wrap items-center justify-between gap-4 rounded-lg bg-lightGray/20 p-4">
+    <div className="mx-auto max-w-4xl space-y-6 rounded-xl bg-white p-4 sm:p-6">
+      <div className="flex flex-col gap-4 rounded-lg bg-lightGray/20 p-4 md:flex-row md:items-center md:justify-between">
         <div>
           <p className="text-lg font-semibold text-primary">{lifecycle.label}</p>
           <p className="text-sm text-primaryGray">
@@ -116,7 +116,7 @@ export function OrderDetailsPage() {
           </p>
         </div>
 
-        <div className="flex flex-wrap items-center gap-2">
+        <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center">
           <Button
             value="Contact Us"
             variant="secondary"
@@ -125,6 +125,7 @@ export function OrderDetailsPage() {
                 `Order ${order.order_number}`
               )}`;
             }}
+            className="w-full sm:w-auto"
           />
           {lifecycle.canCancel && (
             <Button
@@ -132,10 +133,17 @@ export function OrderDetailsPage() {
               variant="secondary"
               disabled={isProcessing}
               onClick={handleCancel}
+              className="w-full sm:w-auto"
             />
           )}
           {lifecycle.canPay && (
-            <Button value="Pay Now" loading={isProcessing} disabled={isProcessing} onClick={handlePay} />
+            <Button
+              value="Pay Now"
+              loading={isProcessing}
+              disabled={isProcessing}
+              onClick={handlePay}
+              className="w-full sm:w-auto"
+            />
           )}
         </div>
       </div>
@@ -148,29 +156,36 @@ export function OrderDetailsPage() {
 
       <div className="divide-y divide-lightGray/60 rounded-lg border border-lightGray">
         {order.items.map((item, index) => (
-          <div key={`${item.id}-${index}`} className="flex gap-4 p-4">
-            <img
-              src={item.image_url}
-              alt={item.name}
-              className="h-16 w-16 flex-shrink-0 rounded-lg border border-lightGray object-cover"
-            />
-            <div className="flex-1">
-              <p className="font-medium text-primary">{item.name}</p>
-              <p className="text-sm text-primaryGray">{item.color}</p>
+          <div
+            key={`${item.id}-${index}`}
+            className="flex flex-col gap-3 p-4 md:flex-row md:items-center md:gap-4"
+          >
+            <div className="flex gap-4 md:min-w-0 md:flex-1">
+              <img
+                src={item.image_url}
+                alt={item.name}
+                className="h-16 w-16 flex-shrink-0 rounded-lg border border-lightGray object-cover"
+              />
+              <div className="min-w-0 flex-1">
+                <p className="truncate font-medium text-primary">{item.name}</p>
+                <p className="text-sm text-primaryGray">{item.color}</p>
+              </div>
             </div>
-            <div className="w-16 text-center text-sm">
-              <p className="text-primaryGray">Qty</p>
-              <p className="font-semibold text-primary">X{item.quantity}</p>
-            </div>
-            <div className="w-24 text-right text-sm">
-              <p className="text-primaryGray">Price</p>
-              <p className="font-semibold text-primary">{formatMoney(Number(item.price_amount || 0))}</p>
+            <div className="grid grid-cols-2 gap-3 text-sm md:flex md:w-auto md:flex-shrink-0 md:gap-4">
+              <div className="md:w-16 md:text-center">
+                <p className="text-primaryGray">Qty</p>
+                <p className="font-semibold text-primary">X{item.quantity}</p>
+              </div>
+              <div className="md:w-24 md:text-right">
+                <p className="text-primaryGray">Price</p>
+                <p className="font-semibold text-primary">{formatMoney(Number(item.price_amount || 0))}</p>
+              </div>
             </div>
           </div>
         ))}
       </div>
 
-      <div className="ml-auto w-full max-w-xs space-y-2 text-sm">
+      <div className="w-full space-y-2 text-sm md:ml-auto md:w-full md:max-w-xs">
         <p className="flex items-center justify-between">
           <span className="text-primaryGray">Subtotal</span>
           <span className="font-medium text-primary">{formatMoney(subtotal)}</span>

--- a/src/pages/MembersPage/components/MemberOrderGroup.tsx
+++ b/src/pages/MembersPage/components/MemberOrderGroup.tsx
@@ -45,7 +45,7 @@ export function MemberOrderGroup({
 
   return (
     <div className="border-b border-lightGray py-4">
-      <div className="flex flex-wrap items-center justify-between gap-3 bg-lightGray/20 px-4 py-3">
+      <div className="flex flex-col gap-3 bg-lightGray/20 px-4 py-3 md:flex-row md:items-center md:justify-between">
         <div className="space-y-1 text-sm">
           <p>
             <span className="text-primaryGray">Order date: </span>
@@ -60,13 +60,14 @@ export function MemberOrderGroup({
         </div>
 
         {(lifecycle.canPay || lifecycle.canCancel) && (
-          <div className="flex items-center gap-2">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
             {lifecycle.canPay && (
               <Button
                 value="Pay Now"
                 loading={isProcessing}
                 disabled={isProcessing}
                 onClick={() => onPay(first)}
+                className="w-full sm:w-auto"
               />
             )}
             {lifecycle.canCancel && (
@@ -75,6 +76,7 @@ export function MemberOrderGroup({
                 variant="secondary"
                 disabled={isProcessing}
                 onClick={() => onCancel(first)}
+                className="w-full sm:w-auto"
               />
             )}
           </div>
@@ -85,42 +87,47 @@ export function MemberOrderGroup({
         {rows.map((row, index) => {
           const isLastRow = index === rows.length - 1;
           return (
-            <div key={`${orderNumber}-${row.id}-${index}`} className="flex gap-4 py-4">
-              <img
-                src={row.image_url}
-                alt={row.name}
-                className="h-16 w-16 flex-shrink-0 rounded-lg border border-lightGray object-cover"
-              />
+            <div
+              key={`${orderNumber}-${row.id}-${index}`}
+              className="flex flex-col gap-3 py-4 md:flex-row md:items-center md:gap-4"
+            >
+              <div className="flex gap-4 md:min-w-0 md:flex-1">
+                <img
+                  src={row.image_url}
+                  alt={row.name}
+                  className="h-16 w-16 flex-shrink-0 rounded-lg border border-lightGray object-cover"
+                />
 
-              <div className="flex-1">
-                <p className="font-medium text-primary">{row.name}</p>
-                <p className="text-sm text-primaryGray">{row.color}</p>
+                <div className="min-w-0 flex-1">
+                  <p className="truncate font-medium text-primary">{row.name}</p>
+                  <p className="text-sm text-primaryGray">{row.color}</p>
+                </div>
               </div>
 
-              <div className="w-16 text-center text-sm">
-                <p className="text-primaryGray">Qty</p>
-                <p className="font-semibold text-primary">X{row.quantity}</p>
+              <div className="grid grid-cols-2 gap-3 text-sm md:flex md:w-auto md:flex-shrink-0 md:gap-4">
+                <div className="md:w-16 md:text-center">
+                  <p className="text-primaryGray">Qty</p>
+                  <p className="font-semibold text-primary">X{row.quantity}</p>
+                </div>
+
+                <div className="md:w-24 md:text-center">
+                  <p className="text-primaryGray">Price</p>
+                  <p className="font-semibold text-primary">
+                    {formatMoney(Number(row.price_amount || 0))}
+                  </p>
+                </div>
               </div>
 
-              <div className="w-24 text-center text-sm">
-                <p className="text-primaryGray">Price</p>
-                <p className="font-semibold text-primary">
-                  {formatMoney(Number(row.price_amount || 0))}
-                </p>
-              </div>
-
-              <div className="w-40 text-right text-sm">
-                {isLastRow && (
-                  <>
-                    <p className="font-semibold text-primary">Total Price:</p>
-                    <p className="text-lg font-bold text-primary">{formatMoney(orderTotal)}</p>
-                    <p className="mt-1 text-primaryGray">{lifecycle.label}</p>
-                    <Link to={detailHref} className="font-medium text-primary underline">
-                      View Order &gt;
-                    </Link>
-                  </>
-                )}
-              </div>
+              {isLastRow && (
+                <div className="border-t border-lightGray/60 pt-3 text-sm md:w-40 md:flex-shrink-0 md:border-t-0 md:pt-0 md:text-right">
+                  <p className="font-semibold text-primary">Total Price:</p>
+                  <p className="text-lg font-bold text-primary">{formatMoney(orderTotal)}</p>
+                  <p className="mt-1 text-primaryGray">{lifecycle.label}</p>
+                  <Link to={detailHref} className="font-medium text-primary underline">
+                    View Order &gt;
+                  </Link>
+                </div>
+              )}
             </div>
           );
         })}

--- a/src/pages/MembersPage/components/MemberOrderGroup.tsx
+++ b/src/pages/MembersPage/components/MemberOrderGroup.tsx
@@ -1,0 +1,130 @@
+import { Link } from "react-router-dom";
+
+import { Button } from "@/components";
+import { encodeQuery } from "@/pages/HomePage/utils";
+import { relativePath } from "@/utils";
+import type { IOrders } from "@/utils";
+import { getOrderLifecycle } from "@/pages/MembersPage/utils/orderLifecycle";
+
+const formatMoney = (amount: number) => `₵ ${amount.toFixed(2)}`;
+
+const formatOrderDate = (value?: string) => {
+  if (!value) return "";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${pad(date.getDate())}/${pad(date.getMonth() + 1)}/${date.getFullYear()} ${pad(
+    date.getHours()
+  )}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`;
+};
+
+interface IProps {
+  orderNumber: string;
+  rows: IOrders[];
+  onPay: (order: IOrders) => void;
+  onCancel: (order: IOrders) => void;
+  isProcessing: boolean;
+}
+
+export function MemberOrderGroup({
+  orderNumber,
+  rows,
+  onPay,
+  onCancel,
+  isProcessing,
+}: IProps) {
+  const first = rows[0];
+  const lifecycle = getOrderLifecycle(first);
+  const orderTotal = rows.reduce(
+    (sum, row) => sum + Number(row.price_amount || 0) * Number(row.quantity || 0),
+    0
+  );
+  const detailHref = `${relativePath.member.market}orders/${encodeQuery(
+    String(first.order_id ?? first.id)
+  )}`;
+
+  return (
+    <div className="border-b border-lightGray py-4">
+      <div className="flex flex-wrap items-center justify-between gap-3 bg-lightGray/20 px-4 py-3">
+        <div className="space-y-1 text-sm">
+          <p>
+            <span className="text-primaryGray">Order date: </span>
+            <span className="font-semibold text-primary">
+              {formatOrderDate(first.created_at || first.order_created_at || first.ordered_at)}
+            </span>
+          </p>
+          <p>
+            <span className="text-primaryGray">Order NO: </span>
+            <span className="font-semibold text-primary">{orderNumber}</span>
+          </p>
+        </div>
+
+        {(lifecycle.canPay || lifecycle.canCancel) && (
+          <div className="flex items-center gap-2">
+            {lifecycle.canPay && (
+              <Button
+                value="Pay Now"
+                loading={isProcessing}
+                disabled={isProcessing}
+                onClick={() => onPay(first)}
+              />
+            )}
+            {lifecycle.canCancel && (
+              <Button
+                value="Cancel Order"
+                variant="secondary"
+                disabled={isProcessing}
+                onClick={() => onCancel(first)}
+              />
+            )}
+          </div>
+        )}
+      </div>
+
+      <div className="divide-y divide-lightGray/60 px-4">
+        {rows.map((row, index) => {
+          const isLastRow = index === rows.length - 1;
+          return (
+            <div key={`${orderNumber}-${row.id}-${index}`} className="flex gap-4 py-4">
+              <img
+                src={row.image_url}
+                alt={row.name}
+                className="h-16 w-16 flex-shrink-0 rounded-lg border border-lightGray object-cover"
+              />
+
+              <div className="flex-1">
+                <p className="font-medium text-primary">{row.name}</p>
+                <p className="text-sm text-primaryGray">{row.color}</p>
+              </div>
+
+              <div className="w-16 text-center text-sm">
+                <p className="text-primaryGray">Qty</p>
+                <p className="font-semibold text-primary">X{row.quantity}</p>
+              </div>
+
+              <div className="w-24 text-center text-sm">
+                <p className="text-primaryGray">Price</p>
+                <p className="font-semibold text-primary">
+                  {formatMoney(Number(row.price_amount || 0))}
+                </p>
+              </div>
+
+              <div className="w-40 text-right text-sm">
+                {isLastRow && (
+                  <>
+                    <p className="font-semibold text-primary">Total Price:</p>
+                    <p className="text-lg font-bold text-primary">{formatMoney(orderTotal)}</p>
+                    <p className="mt-1 text-primaryGray">{lifecycle.label}</p>
+                    <Link to={detailHref} className="font-medium text-primary underline">
+                      View Order &gt;
+                    </Link>
+                  </>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/MembersPage/components/OrderProgressStepper.tsx
+++ b/src/pages/MembersPage/components/OrderProgressStepper.tsx
@@ -1,0 +1,81 @@
+import { CheckCircleIcon } from "@heroicons/react/24/solid";
+
+import { cn } from "@/utils/cn";
+import type { OrderLifecycleStage } from "@/pages/MembersPage/utils/orderLifecycle";
+
+const STEPS = ["Submit Order", "Waiting for Delivery", "Transaction Complete"] as const;
+
+interface IProps {
+  stage: OrderLifecycleStage;
+}
+
+export function OrderProgressStepper({ stage }: IProps) {
+  if (stage === "cancelled") {
+    return (
+      <p className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm font-medium text-red-600 dark:border-red-900/40 dark:bg-red-900/10 dark:text-red-400">
+        This order was cancelled.
+      </p>
+    );
+  }
+
+  if (stage === "payment_failed") {
+    return (
+      <p className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm font-medium text-red-600 dark:border-red-900/40 dark:bg-red-900/10 dark:text-red-400">
+        Payment failed — this order was not completed.
+      </p>
+    );
+  }
+
+  // Step 0 ("Submit Order") is always complete: the order exists.
+  // Step 1 ("Waiting for Delivery") completes once payment succeeds.
+  // Step 2 ("Transaction Complete") completes once delivery is marked delivered.
+  const completedSteps =
+    stage === "waiting_payment" ? 0 : stage === "waiting_delivery" ? 1 : 2;
+
+  return (
+    <div className="overflow-x-auto">
+      <div className="flex items-center min-w-max">
+        {STEPS.map((step, index) => {
+          const isComplete = index <= completedSteps;
+          const isCurrent = index === completedSteps + 1;
+          const isLast = index === STEPS.length - 1;
+
+          return (
+            <div key={step} className="flex flex-1 items-center last:flex-none">
+              <div className="flex flex-col items-center gap-1">
+                <div
+                  className={cn(
+                    "flex h-6 w-6 items-center justify-center rounded-full border-2 text-xs font-semibold",
+                    isComplete
+                      ? "border-primary bg-primary text-white"
+                      : isCurrent
+                      ? "border-primary text-primary"
+                      : "border-lightGray text-primaryGray"
+                  )}
+                >
+                  {isComplete ? <CheckCircleIcon className="h-4 w-4" /> : index + 1}
+                </div>
+                <span
+                  className={cn(
+                    "whitespace-nowrap text-[11px]",
+                    isComplete || isCurrent ? "font-medium text-primary" : "text-primaryGray"
+                  )}
+                >
+                  {step}
+                </span>
+              </div>
+              {!isLast && (
+                <div
+                  className={cn(
+                    "mx-1 h-0.5 flex-1",
+                    index < completedSteps ? "bg-primary" : "bg-lightGray"
+                  )}
+                />
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/MembersPage/utils/orderLifecycle.ts
+++ b/src/pages/MembersPage/utils/orderLifecycle.ts
@@ -1,0 +1,61 @@
+import type { IOrders, IOrderDetail } from "@/utils";
+
+export type OrderLifecycleStage =
+  | "waiting_payment"
+  | "payment_failed"
+  | "waiting_delivery"
+  | "complete"
+  | "cancelled";
+
+export interface OrderLifecycle {
+  stage: OrderLifecycleStage;
+  label: string;
+  canPay: boolean;
+  canCancel: boolean;
+}
+
+type LifecycleInput = Pick<
+  IOrders | IOrderDetail,
+  "payment_status" | "delivery_status"
+>;
+
+const STAGE_LABELS: Record<OrderLifecycleStage, string> = {
+  waiting_payment: "Waiting for Payment",
+  payment_failed: "Payment Failed",
+  waiting_delivery: "Waiting for Delivery",
+  complete: "Transaction Complete",
+  cancelled: "Order Cancelled",
+};
+
+/**
+ * Single source of truth for order status wording, used by both the
+ * member order list (badges) and the order detail page (progress bar).
+ * There is no separate "Been Shipped" stage — delivery_status === "shipped"
+ * folds into "waiting_delivery" since there is no real shipment-tracking
+ * data model to justify a distinct stage.
+ */
+export function getOrderLifecycle(order: LifecycleInput): OrderLifecycle {
+  const paymentStatus = String(order.payment_status || "").toLowerCase();
+  const deliveryStatus = String(order.delivery_status || "").toLowerCase();
+
+  let stage: OrderLifecycleStage;
+  if (deliveryStatus === "cancelled") {
+    stage = "cancelled";
+  } else if (paymentStatus === "failed") {
+    stage = "payment_failed";
+  } else if (paymentStatus === "pending") {
+    stage = "waiting_payment";
+  } else if (deliveryStatus === "delivered") {
+    stage = "complete";
+  } else {
+    // paid (success), delivery pending or shipped
+    stage = "waiting_delivery";
+  }
+
+  return {
+    stage,
+    label: STAGE_LABELS[stage],
+    canPay: stage === "waiting_payment",
+    canCancel: stage === "waiting_payment",
+  };
+}

--- a/src/routes/appRoutes.tsx
+++ b/src/routes/appRoutes.tsx
@@ -68,6 +68,7 @@ import { ProductDetailsPage } from "@/pages/MembersPage/Pages/ProductDetailsPage
 import { CheckOutPage } from "@/pages/MembersPage/Pages/CheckOutPage";
 import ProductsPage from "@/pages/MembersPage/Pages/ProductsPage";
 import { MyOrders } from "@/pages/MembersPage/Pages/MyOrders";
+import { OrderDetailsPage } from "@/pages/MembersPage/Pages/OrderDetailsPage";
 import VerifyPayment from "@/pages/MembersPage/Pages/VerifyPayment.js";
 import GivingComplete from "@/pages/MembersPage/Pages/GivingComplete.js";
 import PledgeComplete from "@/pages/MembersPage/Pages/PledgeComplete.js";
@@ -1174,6 +1175,12 @@ export const routes: AppRoute[] = [
             path: relativePath.member.orders,
             name: "Orders",
             element: <MyOrders />,
+            isPrivate: false,
+          },
+          {
+            path: relativePath.member.orderDetails,
+            name: "Order Details",
+            element: <OrderDetailsPage />,
             isPrivate: false,
           },
           {

--- a/src/utils/api/apiFetch.ts
+++ b/src/utils/api/apiFetch.ts
@@ -30,6 +30,7 @@ import {
 } from "./lifeCenter/interfaces";
 import type {
   IMarket,
+  IOrderDetail,
   IOrders,
   IProductType,
   IProductTypeResponse,
@@ -669,6 +670,12 @@ export class ApiCalls {
     query?: QueryType
   ): Promise<ApiResponse<IOrders[]>> => {
     return this.fetchFromApi(`orders/get-orders-by-user/`, query);
+  };
+
+  fetchOrderById = (
+    query?: QueryType
+  ): Promise<ApiResponse<IOrderDetail>> => {
+    return this.fetchFromApi(`orders/get-order-by-id`, query);
   };
 
   // Fetch staff appointment availability

--- a/src/utils/api/apiPut.ts
+++ b/src/utils/api/apiPut.ts
@@ -31,6 +31,7 @@ import type {
   IProductType,
   IProduct,
   IOrders,
+  IOrderDetail,
 } from "./marketPlace/interface";
 import type {
   Appointment,
@@ -489,6 +490,12 @@ export class ApiUpdateCalls {
     }
   ): Promise<ApiResponse<IOrders>> => {
     return this.apiExecution.updateData("orders/update-delivery-status", payload);
+  };
+
+  cancelOrder = (
+    payload: { id: number | string }
+  ): Promise<ApiResponse<IOrderDetail>> => {
+    return this.apiExecution.updateData("orders/cancel-order", payload);
   };
 
   // uodate church attendance

--- a/src/utils/api/marketPlace/interface.ts
+++ b/src/utils/api/marketPlace/interface.ts
@@ -148,6 +148,43 @@ export interface IOrders extends ICartItem, IUserDetails {
   id: string | number;
 }
 
+// Unflattened order shape returned by GET /orders/get-order-by-id — one
+// order with a real items[] array, as opposed to IOrders which is one
+// flattened order+item row (mirrors the Backend's flattenOrders output used
+// for order lists).
+export interface IOrderItem {
+  id: number;
+  name: string;
+  image_url: string;
+  color: string;
+  size: string;
+  price_amount: number;
+  price_currency: string;
+  quantity: number;
+  product_type: string;
+  product_category: string;
+}
+
+export interface IOrderBillingDetails {
+  first_name: string;
+  last_name: string;
+  email: string;
+  phone_number: string;
+  country: string;
+}
+
+export interface IOrderDetail {
+  id: number;
+  order_number: string;
+  total_amount: number;
+  payment_status: PaymentStatus;
+  delivery_status: "pending" | "shipped" | "delivered" | "cancelled";
+  created_at: string;
+  reference: string;
+  items: IOrderItem[];
+  billing_details?: IOrderBillingDetails | null;
+}
+
 export interface IProductSlice {
   products: IProductTypeResponse[];
   setProducts: (products: IProductTypeResponse[]) => void;

--- a/src/utils/const.ts
+++ b/src/utils/const.ts
@@ -118,6 +118,7 @@ export const relativePath = {
     productDetails: "/member/market/product/:id",
     checkOut: "/member/market/check-out",
     orders: "/member/market/orders",
+    orderDetails: "/member/market/orders/:id",
     verify_payment: "/member/market/verify_payment/member",
     lifeCenter: "/member/life-center",
     giving: "/member/giving",


### PR DESCRIPTION
## Summary
Redesigns the Members-panel "My Orders" list and adds a real `/member/market/orders/:id` order-detail page, matching supplied target designs.

- Order list now groups flattened order rows by `order_number` into cards (date/order-no header, Pay Now/Cancel Order gated on status, stacked product rows, total + status + "View Order" link) instead of one-row-per-line-item.
- New routed `OrderDetailsPage`: status header (Contact Us via mailto, Pay Now/Cancel Order gated on status), a 3-stage progress bar (Submit Order → Waiting for Delivery → Transaction Complete), a shipping-info placeholder (no tracking data model exists yet), a product table, and a Subtotal + Order Total price block.
- Wires the previously-unused `fetchOrderById` endpoint and the new `cancelOrder` endpoint (see companion Backend PR https://github.com/WWW-Ministries-Project/Backend/pull/425) into the Frontend API layer.
- Shared `getOrderLifecycle` helper is the single source of truth for status labels/action gating across both pages.

Design spec: `docs/superpowers/specs/2026-08-20-member-order-view-design.md`
Implementation plan: `docs/superpowers/plans/2026-08-20-member-order-view.md`

## Review history
Went through task-by-task implementation + spec/quality review. Review caught and fixed real bugs before merge:
- `cancelOrder` service originally never released reserved stock, and had a TOCTOU race against concurrent payment webhooks — both fixed.
- `MyOrders.tsx`'s in-flight-request tracking was a single shared key that could corrupt state across concurrently-acted-on orders — replaced with a per-order `Set`.
- A loading/error gap that could flash "no orders yet" before the fetch resolved, or permanently on error — fixed.
- Stale pagination after a cancel shrinks the list — clamped.
- Mobile responsiveness pass on both new components (stacking below `md:`, full-width price block on mobile).

Final holistic review: no critical/important issues remaining, `tsc --noEmit` clean, no new lint violations.

**Depends on:** https://github.com/WWW-Ministries-Project/Backend/pull/425 (the `cancel-order`/`get-order-by-id` endpoints this PR calls).

## Testing
No test runner is configured in this repo. `npx tsc --noEmit` and `npm run lint` are clean for every file this PR touches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)