### PR TITLE
fix: mobile responsiveness across member portal

### DIFF
--- a/src/components/NotificationCard.tsx
+++ b/src/components/NotificationCard.tsx
@@ -141,7 +141,7 @@ export const NotificationCard = () => {
   return (
     <section
       style={{ top: "calc(var(--app-header-height) + 1rem)" }}
-      className="pointer-events-none fixed right-4 z-[130] flex w-[calc(100%-2rem)] max-w-xl flex-col gap-3 sm:w-full"
+      className="pointer-events-none fixed right-4 z-[130] flex w-[calc(100%-2rem)] max-w-xl flex-col gap-3"
       aria-label="Notifications"
     >
       {alerts.map((alert) => (

--- a/src/pages/HomePage/Components/reusable/TableComponent.tsx
+++ b/src/pages/HomePage/Components/reusable/TableComponent.tsx
@@ -151,13 +151,13 @@ function TableComponent<TData>({
     <div className={`overflow-x-auto ${props.className}`}>
       {/* Bulk Actions Bar */}
       {enableSelection && selectedCount > 0 && bulkActions.length > 0 && (
-        <div className="bg-blue-50 border border-blue-200 rounded-lg p-4 mb-4 flex items-center justify-between">
+        <div className="bg-blue-50 border border-blue-200 rounded-lg p-4 mb-4 flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
           <div className="flex items-center space-x-2">
             <span className="text-sm font-medium text-blue-700">
               {selectedCount} item{selectedCount !== 1 ? 's' : ''} selected
             </span>
           </div>
-          <div className="flex items-center space-x-2">
+          <div className="flex flex-wrap items-center gap-2">
             {bulkActions.map((action) => (
               <button
                 key={action.value}

--- a/src/pages/MembersPage/Pages/GradingPanel.tsx
+++ b/src/pages/MembersPage/Pages/GradingPanel.tsx
@@ -486,10 +486,10 @@ const GradingPanel = () => {
           <ArrowLeftIcon className="h-4 w-4" />
           Back to assignments
         </button>
-        <div className="flex items-start justify-between">
+        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
           <div>
             <h2 className="text-lg font-semibold text-primary">{assignment.title}</h2>
-            <div className="mt-2 flex items-center gap-4  text-primaryGray">
+            <div className="mt-2 flex flex-wrap items-center gap-4  text-primaryGray">
               <span className="flex items-center gap-1">
                 <UsersIcon className="h-4 w-4" />
                 {totalCount} submissions
@@ -505,7 +505,7 @@ const GradingPanel = () => {
             </div>
           </div>
           {/* Progress bar */}
-          <div className="text-right">
+          <div className="text-left md:text-right">
             <p className=" font-medium text-primary">
               {progress}% complete
             </p>

--- a/src/pages/MembersPage/Pages/Market.tsx
+++ b/src/pages/MembersPage/Pages/Market.tsx
@@ -43,18 +43,14 @@ const Market = () => {
 
   return (
     <MarketLayout title={routeName}>
-      <div className="bg-white p-6 space-y-5 container mx-auto">
-        <div className="p-6 space-y-5">
-          <div className="w-fit">
-          <TabSelection
-            tabs={["Products", "Orders"]}
-            onTabSelect={handleSelectedTab}
-            selectedTab={routeName || "Products"}
-          />
-        </div>
+      <div className="bg-white p-4 sm:p-6 space-y-4 sm:space-y-5 container mx-auto">
+        <TabSelection
+          tabs={["Products", "Orders"]}
+          onTabSelect={handleSelectedTab}
+          selectedTab={routeName || "Products"}
+        />
 
         <Outlet />
-        </div>
       </div>
     </MarketLayout>
   );


### PR DESCRIPTION
## Summary
Fixes two reported mobile bugs and closes out a full responsive audit of the member portal.

- **Market page tab bar**: `Market.tsx` nested two `p-6` wrapper divs (doubled padding, ~48px lost on each side on a 375px screen) plus a redundant `w-fit` div around an already-`w-full` `TabSelection` — collapsed to one responsive padding layer (`p-4 sm:p-6`), dropped the no-op wrapper.
- **Notification card off-screen**: `NotificationCard`'s fixed-position container mixed a margin-safe `w-[calc(100%-2rem)]` base width with `sm:w-full` — combined with `right-4` and no matching `left`, this pushed the card off-screen to the left at ≥450px (this project's `sm` breakpoint) until `max-w-xl` finally capped it past 576px. Removed `sm:w-full` so width stays margin-safe at every breakpoint.
- **Full audit**: read all 20 member-portal pages + 5 shared marketplace components. 19 pages and all 5 components already followed correct responsive patterns (`grid-cols-1` defaults, `flex-col`→`lg:flex-row` stacking, `overflow-x-auto` on tables, viewport-safe modals). Only `GradingPanel.tsx` had a real gap — its header (title + non-wrapping stats row + fixed-width progress bar) overflowed on mobile; fixed to stack below `md:`. Its bulk-actions bar overflow traced to the shared `TableComponent`, which rendered `bulkActions` in a non-wrapping row — fixed there instead of special-casing `GradingPanel`, so it benefits every page using bulk actions.

## Testing
No test runner configured in this repo. `npx tsc --noEmit` clean. No new lint violations introduced (4 pre-existing `no-explicit-any` errors in `TableComponent.tsx` predate this branch, confirmed against `development`'s tip, unrelated to the lines touched here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)